### PR TITLE
feature: add ability to override "_all" property decorators for single actions on ResolversEnhanceMap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -368,6 +368,17 @@ applyResolversEnhanceMap({
 });
 ```
 
+If you apply decorators using the  `_all` property you can override the configuration on other fields by passing a function that returns an array of decorators which gets the `_all` decorators if there is any to the field you want to override:
+
+```ts
+applyResolversEnhanceMap({
+  Client:{
+    _all: [Authorized()],
+    createClient: (decorators) => [Authorized("ADMIN", "DEVELOPER")]
+  }
+})
+```
+
 #### Additional decorators for Prisma schema classes and fields
 
 If you need to apply some decorators, like `@Authorized` or `@Extensions`, on the model `@ObjectType` and its fields, you can use similar pattern as for the resolver actions described above.

--- a/src/generator/generate-enhance.ts
+++ b/src/generator/generate-enhance.ts
@@ -262,9 +262,11 @@ export function generateEnhanceMap(
 
     export type ResolverActionConfig = MethodDecorator[] | (decorators: MethodDecorator[]) => MethodDecorator[];
 
-    export type ResolverActionsConfig<
-      TModel extends ResolverModelNames
-    > = Partial<Record<ModelResolverActionNames<TModel> | "_all", MethodDecorator[]>>;
+    export type ResolverActionsConfig<TModel extends ResolverModelNames> = {
+      [K in ModelResolverActionNames<TModel> | "_all"]?: K extends "_all"
+        ? MethodDecorator[]
+        : ResolverActionConfig;
+    };
 
     export type ResolversEnhanceMap = {
       [TModel in ResolverModelNames]?: ResolverActionsConfig<TModel>;

--- a/tests/regression/__snapshots__/enhance.ts.snap
+++ b/tests/regression/__snapshots__/enhance.ts.snap
@@ -177,6 +177,8 @@ type ModelResolverActionNames<
   TModel extends ResolverModelNames
   > = keyof typeof crudResolversMap[TModel][\\"prototype\\"];
 
+export type ResolverActionConfig = MethodDecorator[] | (decorators: MethodDecorator[]) => MethodDecorator[];
+
 export type ResolverActionsConfig<
   TModel extends ResolverModelNames
   > = Partial<Record<ModelResolverActionNames<TModel> | \\"_all\\", MethodDecorator[]>>;
@@ -197,6 +199,12 @@ export function applyResolversEnhanceMap(
       const allActionsDecorators = resolverActionsConfig._all;
       const resolverActionNames = resolversInfo[modelName as keyof typeof resolversInfo];
       for (const resolverActionName of resolverActionNames) {
+        const resolverActionIsOverridden =
+          typeof resolverActionsConfig[
+          resolverActionName as ModelResolverActionNames<ResolverModelNames>
+          ] === \\"function\\";
+        if (resolverActionIsOverridden) continue;
+
         const actionTarget = (actionResolversConfig[
           resolverActionName as keyof typeof actionResolversConfig
         ] as Function).prototype;
@@ -218,9 +226,15 @@ export function applyResolversEnhanceMap(
       it => it !== \\"_all\\"
     );
     for (const resolverActionName of resolverActionsToApply) {
-      const decorators = resolverActionsConfig[
+      const decoratorsConfig = resolverActionsConfig[
         resolverActionName as keyof typeof resolverActionsConfig
-      ] as MethodDecorator[];
+      ] as ResolverActionConfig;
+
+      const decorators: MethodDecorator[] =
+        typeof decoratorsConfig === \\"function\\"
+          ? decoratorsConfig(resolverActionsConfig._all || [])
+          : decoratorsConfig;
+
       const actionTarget = (actionResolversConfig[
         resolverActionName as keyof typeof actionResolversConfig
       ] as Function).prototype;
@@ -507,364 +521,5 @@ export * from \\"./scalars\\";
 export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 export const resolvers = [...crudResolvers, ...relationResolvers] as unknown as NonEmptyArray<Function>;
-"
-`;
-
-exports[`resolvers enhance should emit enhance file properly even in model has no relations: enhance 1`] = `
-"import { ClassType } from \\"type-graphql\\";
-import * as crudResolvers from \\"./resolvers/crud/resolvers-crud.index\\";
-import * as actionResolvers from \\"./resolvers/crud/resolvers-actions.index\\";
-import * as models from \\"./models\\";
-import * as outputTypes from \\"./resolvers/outputs\\";
-import * as inputTypes from \\"./resolvers/inputs\\";
-import * as argsTypes from \\"./resolvers/crud/args.index\\";
-
-const crudResolversMap = {
-  Post: crudResolvers.PostCrudResolver
-};
-const actionResolversMap = {
-  Post: {
-    post: actionResolvers.FindUniquePostResolver,
-    findFirstPost: actionResolvers.FindFirstPostResolver,
-    posts: actionResolvers.FindManyPostResolver,
-    createPost: actionResolvers.CreatePostResolver,
-    createManyPost: actionResolvers.CreateManyPostResolver,
-    deletePost: actionResolvers.DeletePostResolver,
-    updatePost: actionResolvers.UpdatePostResolver,
-    deleteManyPost: actionResolvers.DeleteManyPostResolver,
-    updateManyPost: actionResolvers.UpdateManyPostResolver,
-    upsertPost: actionResolvers.UpsertPostResolver,
-    aggregatePost: actionResolvers.AggregatePostResolver,
-    groupByPost: actionResolvers.GroupByPostResolver
-  }
-};
-const resolversInfo = {
-  Post: [\\"post\\", \\"findFirstPost\\", \\"posts\\", \\"createPost\\", \\"createManyPost\\", \\"deletePost\\", \\"updatePost\\", \\"deleteManyPost\\", \\"updateManyPost\\", \\"upsertPost\\", \\"aggregatePost\\", \\"groupByPost\\"]
-};
-const modelsInfo = {
-  Post: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"]
-};
-const inputsInfo = {
-  PostWhereInput: [\\"AND\\", \\"OR\\", \\"NOT\\", \\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostOrderByInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostWhereUniqueInput: [\\"uuid\\"],
-  PostScalarWhereWithAggregatesInput: [\\"AND\\", \\"OR\\", \\"NOT\\", \\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostCreateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostUpdateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostCreateManyInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  PostUpdateManyMutationInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
-  StringFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  BoolFilter: [\\"equals\\", \\"not\\"],
-  StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"not\\"],
-  StringWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  StringFieldUpdateOperationsInput: [\\"set\\"],
-  DateTimeFieldUpdateOperationsInput: [\\"set\\"],
-  BoolFieldUpdateOperationsInput: [\\"set\\"],
-  NullableStringFieldUpdateOperationsInput: [\\"set\\"],
-  NestedStringFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\"],
-  NestedDateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedBoolFilter: [\\"equals\\", \\"not\\"],
-  NestedStringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\"],
-  NestedStringWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  NestedIntFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedDateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"not\\"]
-};
-const outputsInfo = {
-  AggregatePost: [\\"_count\\", \\"_min\\", \\"_max\\"],
-  PostGroupBy: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  AffectedRowsOutput: [\\"count\\"],
-  PostCountAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\", \\"_all\\"],
-  PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
-  PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"]
-};
-const argsInfo = {
-  FindUniquePostArgs: [\\"where\\"],
-  FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
-  FindManyPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
-  CreatePostArgs: [\\"data\\"],
-  CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
-  DeletePostArgs: [\\"where\\"],
-  UpdatePostArgs: [\\"data\\", \\"where\\"],
-  DeleteManyPostArgs: [\\"where\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
-  UpsertPostArgs: [\\"where\\", \\"create\\", \\"update\\"],
-  AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
-  GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"]
-};
-
-type ResolverModelNames = keyof typeof crudResolversMap;
-
-type ModelResolverActionNames<
-  TModel extends ResolverModelNames
-  > = keyof typeof crudResolversMap[TModel][\\"prototype\\"];
-
-export type ResolverActionsConfig<
-  TModel extends ResolverModelNames
-  > = Partial<Record<ModelResolverActionNames<TModel> | \\"_all\\", MethodDecorator[]>>;
-
-export type ResolversEnhanceMap = {
-  [TModel in ResolverModelNames]?: ResolverActionsConfig<TModel>;
-};
-
-export function applyResolversEnhanceMap(
-  resolversEnhanceMap: ResolversEnhanceMap,
-) {
-  for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
-    const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
-    const crudTarget = crudResolversMap[modelName].prototype;
-    const resolverActionsConfig = resolversEnhanceMap[modelName]!;
-    const actionResolversConfig = actionResolversMap[modelName];
-    if (resolverActionsConfig._all) {
-      const allActionsDecorators = resolverActionsConfig._all;
-      const resolverActionNames = resolversInfo[modelName as keyof typeof resolversInfo];
-      for (const resolverActionName of resolverActionNames) {
-        const actionTarget = (actionResolversConfig[
-          resolverActionName as keyof typeof actionResolversConfig
-        ] as Function).prototype;
-        for (const allActionsDecorator of allActionsDecorators) {
-          allActionsDecorator(
-            crudTarget,
-            resolverActionName,
-            Object.getOwnPropertyDescriptor(crudTarget, resolverActionName)!,
-          );
-          allActionsDecorator(
-            actionTarget,
-            resolverActionName,
-            Object.getOwnPropertyDescriptor(actionTarget, resolverActionName)!,
-          );
-        }
-      }
-    }
-    const resolverActionsToApply = Object.keys(resolverActionsConfig).filter(
-      it => it !== \\"_all\\"
-    );
-    for (const resolverActionName of resolverActionsToApply) {
-      const decorators = resolverActionsConfig[
-        resolverActionName as keyof typeof resolverActionsConfig
-      ] as MethodDecorator[];
-      const actionTarget = (actionResolversConfig[
-        resolverActionName as keyof typeof actionResolversConfig
-      ] as Function).prototype;
-      for (const decorator of decorators) {
-        decorator(
-          crudTarget,
-          resolverActionName,
-          Object.getOwnPropertyDescriptor(crudTarget, resolverActionName)!,
-        );
-        decorator(
-          actionTarget,
-          resolverActionName,
-          Object.getOwnPropertyDescriptor(actionTarget, resolverActionName)!,
-        );
-      }
-    }
-  }
-}
-
-type TypeConfig = {
-  class?: ClassDecorator[];
-  fields?: FieldsConfig;
-};
-
-type FieldsConfig<TTypeKeys extends string = string> = Partial<
-  Record<TTypeKeys | \\"_all\\", PropertyDecorator[]>
->;
-
-function applyTypeClassEnhanceConfig<
-  TEnhanceConfig extends TypeConfig,
-  TType extends object
->(
-  enhanceConfig: TEnhanceConfig,
-  typeClass: ClassType<TType>,
-  typePrototype: TType,
-  typeFieldNames: string[]
-) {
-  if (enhanceConfig.class) {
-    for (const decorator of enhanceConfig.class) {
-      decorator(typeClass);
-    }
-  }
-  if (enhanceConfig.fields) {
-    if (enhanceConfig.fields._all) {
-      const allFieldsDecorators = enhanceConfig.fields._all;
-      for (const typeFieldName of typeFieldNames) {
-        for (const allFieldsDecorator of allFieldsDecorators) {
-          allFieldsDecorator(typePrototype, typeFieldName);
-        }
-      }
-    }
-    const configFieldsToApply = Object.keys(enhanceConfig.fields).filter(
-      it => it !== \\"_all\\"
-    );
-    for (const typeFieldName of configFieldsToApply) {
-      const fieldDecorators = enhanceConfig.fields[typeFieldName]!;
-      for (const fieldDecorator of fieldDecorators) {
-        fieldDecorator(typePrototype, typeFieldName);
-      }
-    }
-  }
-}
-
-type ModelNames = keyof typeof models;
-
-type ModelFieldNames<TModel extends ModelNames> = Exclude<
-  keyof typeof models[TModel][\\"prototype\\"],
-  number | symbol
->;
-
-type ModelFieldsConfig<TModel extends ModelNames> = FieldsConfig<
-  ModelFieldNames<TModel>
->;
-
-export type ModelConfig<TModel extends ModelNames> = {
-  class?: ClassDecorator[];
-  fields?: ModelFieldsConfig<TModel>;
-};
-
-export type ModelsEnhanceMap = {
-  [TModel in ModelNames]?: ModelConfig<TModel>;
-};
-
-export function applyModelsEnhanceMap(modelsEnhanceMap: ModelsEnhanceMap) {
-  for (const modelsEnhanceMapKey of Object.keys(modelsEnhanceMap)) {
-    const modelName = modelsEnhanceMapKey as keyof typeof modelsEnhanceMap;
-    const modelConfig = modelsEnhanceMap[modelName]!;
-    const modelClass = models[modelName];
-    const modelTarget = modelClass.prototype;
-    applyTypeClassEnhanceConfig(
-      modelConfig,
-      modelClass,
-      modelTarget,
-      modelsInfo[modelName as keyof typeof modelsInfo],
-    );
-  }
-}
-
-type OutputTypesNames = keyof typeof outputTypes;
-
-type OutputTypeFieldNames<TOutput extends OutputTypesNames> = Exclude<
-  keyof typeof outputTypes[TOutput][\\"prototype\\"],
-  number | symbol
->;
-
-type OutputTypeFieldsConfig<
-  TOutput extends OutputTypesNames
-  > = FieldsConfig<OutputTypeFieldNames<TOutput>>;
-
-export type OutputTypeConfig<TOutput extends OutputTypesNames> = {
-  class?: ClassDecorator[];
-  fields?: OutputTypeFieldsConfig<TOutput>;
-};
-
-export type OutputTypesEnhanceMap = {
-  [TOutput in OutputTypesNames]?: OutputTypeConfig<TOutput>;
-};
-
-export function applyOutputTypesEnhanceMap(
-  outputTypesEnhanceMap: OutputTypesEnhanceMap,
-) {
-  for (const outputTypeEnhanceMapKey of Object.keys(outputTypesEnhanceMap)) {
-    const outputTypeName = outputTypeEnhanceMapKey as keyof typeof outputTypesEnhanceMap;
-    const typeConfig = outputTypesEnhanceMap[outputTypeName]!;
-    const typeClass = outputTypes[outputTypeName];
-    const typeTarget = typeClass.prototype;
-    applyTypeClassEnhanceConfig(
-      typeConfig,
-      typeClass,
-      typeTarget,
-      outputsInfo[outputTypeName as keyof typeof outputsInfo],
-    );
-  }
-}
-
-type InputTypesNames = keyof typeof inputTypes;
-
-type InputTypeFieldNames<TInput extends InputTypesNames> = Exclude<
-  keyof typeof inputTypes[TInput][\\"prototype\\"],
-  number | symbol
->;
-
-type InputTypeFieldsConfig<
-  TInput extends InputTypesNames
-  > = FieldsConfig<InputTypeFieldNames<TInput>>;
-
-export type InputTypeConfig<TInput extends InputTypesNames> = {
-  class?: ClassDecorator[];
-  fields?: InputTypeFieldsConfig<TInput>;
-};
-
-export type InputTypesEnhanceMap = {
-  [TInput in InputTypesNames]?: InputTypeConfig<TInput>;
-};
-
-export function applyInputTypesEnhanceMap(
-  inputTypesEnhanceMap: InputTypesEnhanceMap,
-) {
-  for (const inputTypeEnhanceMapKey of Object.keys(inputTypesEnhanceMap)) {
-    const inputTypeName = inputTypeEnhanceMapKey as keyof typeof inputTypesEnhanceMap;
-    const typeConfig = inputTypesEnhanceMap[inputTypeName]!;
-    const typeClass = inputTypes[inputTypeName];
-    const typeTarget = typeClass.prototype;
-    applyTypeClassEnhanceConfig(
-      typeConfig,
-      typeClass,
-      typeTarget,
-      inputsInfo[inputTypeName as keyof typeof inputsInfo],
-    );
-  }
-}
-
-type ArgsTypesNames = keyof typeof argsTypes;
-
-type ArgFieldNames<TArgsType extends ArgsTypesNames> = Exclude<
-  keyof typeof argsTypes[TArgsType][\\"prototype\\"],
-  number | symbol
->;
-
-type ArgFieldsConfig<
-  TArgsType extends ArgsTypesNames
-  > = FieldsConfig<ArgFieldNames<TArgsType>>;
-
-export type ArgConfig<TArgsType extends ArgsTypesNames> = {
-  class?: ClassDecorator[];
-  fields?: ArgFieldsConfig<TArgsType>;
-};
-
-export type ArgsTypesEnhanceMap = {
-  [TArgsType in ArgsTypesNames]?: ArgConfig<TArgsType>;
-};
-
-export function applyArgsTypesEnhanceMap(
-  argsTypesEnhanceMap: ArgsTypesEnhanceMap,
-) {
-  for (const argsTypesEnhanceMapKey of Object.keys(argsTypesEnhanceMap)) {
-    const argsTypeName = argsTypesEnhanceMapKey as keyof typeof argsTypesEnhanceMap;
-    const typeConfig = argsTypesEnhanceMap[argsTypeName]!;
-    const typeClass = argsTypes[argsTypeName];
-    const typeTarget = typeClass.prototype;
-    applyTypeClassEnhanceConfig(
-      typeConfig,
-      typeClass,
-      typeTarget,
-      argsInfo[argsTypeName as keyof typeof argsInfo],
-    );
-  }
-}
-
-
-
-
-
-
 "
 `;

--- a/tests/regression/__snapshots__/enhance.ts.snap
+++ b/tests/regression/__snapshots__/enhance.ts.snap
@@ -179,9 +179,11 @@ type ModelResolverActionNames<
 
 export type ResolverActionConfig = MethodDecorator[] | (decorators: MethodDecorator[]) => MethodDecorator[];
 
-export type ResolverActionsConfig<
-  TModel extends ResolverModelNames
-  > = Partial<Record<ModelResolverActionNames<TModel> | \\"_all\\", MethodDecorator[]>>;
+export type ResolverActionsConfig<TModel extends ResolverModelNames> = {
+  [K in ModelResolverActionNames<TModel> | \\"_all\\"]?: K extends \\"_all\\"
+  ? MethodDecorator[]
+  : ResolverActionConfig;
+};
 
 export type ResolversEnhanceMap = {
   [TModel in ResolverModelNames]?: ResolverActionsConfig<TModel>;


### PR DESCRIPTION
If we use `_all` field in resolver enhancement map it applies to all actions even ones that don't need to be, for example if we apply `Authorized(Role.ADMIN)` decorator to `_all`  it is not only applied on the create/update/delete resolvers it also applies on the read resolver and if you want to avoid such configuration you have to remove the `_all` field and write all the crud actions with the wanted decorators.

This pull request will improve the resolver enhancement config actions to accept an array of decorators (old implementation), or a function that gets the decorators that are passed in the `_all` field and allows returning of the same decorators or new ones.

closes #136 