### PR TITLE
Minor grammar changes

### DIFF
--- a/website/src/components/HomepageFeatures.tsx
+++ b/website/src/components/HomepageFeatures.tsx
@@ -34,12 +34,12 @@ const FeatureList: FeatureDefinition[] = [
     ),
   },
   {
-    title: "Extensible to the Needs",
+    title: "Extensible Design",
     Svg: maximizeSvg,
     description: (
       <>
         Reuse generated classes to create custom resolvers with ease. Combine
-        them with generated CRUD resolvers to compose the GraphQL API from the
+        them with generated CRUD resolvers to compose the GraphQL API of your
         dreams.
       </>
     ),


### PR DESCRIPTION
Grammar-wise "the needs" and "the dreams" don't work because they aren't specific nouns. You could use "Your needs" and "your dreams" to make it correct, but using "your" twice sounds funny as well. You can also just remove those portions, but these edits are a a simple replacement.