### PR TITLE
Performance: Removing indentation by traversing all files

### DIFF
--- a/src/generator/generate-code.ts
+++ b/src/generator/generate-code.ts
@@ -1,5 +1,11 @@
 import { DMMF as PrismaDMMF } from "@prisma/client/runtime";
-import { Project, ScriptTarget, ModuleKind, CompilerOptions } from "ts-morph";
+import {
+  Project,
+  ScriptTarget,
+  ModuleKind,
+  CompilerOptions,
+  IndentationText,
+} from "ts-morph";
 import path from "path";
 
 import { noop } from "./helpers";
@@ -81,6 +87,9 @@ export default async function generateCode(
         declaration: true,
         importHelpers: true,
       }),
+    },
+    manipulationSettings: {
+      indentationText: IndentationText.TwoSpaces,
     },
   });
   const resolversDirPath = path.resolve(baseDirPath, resolversFolderName);
@@ -522,9 +531,6 @@ export default async function generateCode(
   if (emitTranspiledCode) {
     await project.emit();
   } else {
-    for (const file of project.getSourceFiles()) {
-      file.formatText({ indentSize: 2 });
-    }
     await project.save();
   }
 }


### PR DESCRIPTION
# Description
Basically, this PR removes the indentation on the last step, we were iterating over all files created in a `for .. of` What does this mean? The ForOf runs serially, so we're indenting every file one per time. with this change, every time we write a new file we're formatting with the `indentSize: 2`.

# How it was tested
I used the schema that I'm taking 60 seconds to generate the times every day in my current job. We have:
- 88 Models
- 90 Enums
- 110 Relations

# Results
First of all i used a profiler to try to figure out what's taking more time to generate the types. This part of the code was taking 17 seconds:
```ts
    for (const file of project.getSourceFiles()) {
      file.formatText({ indentSize: 2 });
    }
```
So, I removed it and now it takes just 35~40 secs to generate all the types

# Other Solutions
- Do we really need to identate these files?
- Maybe we can create a proxy function to identate the files instead of need to call `formatText` every time