### PR TITLE
add generator option to add some redundant decorator types

### DIFF
--- a/src/cli/prisma-generator.ts
+++ b/src/cli/prisma-generator.ts
@@ -43,6 +43,9 @@ export async function generate(options: GeneratorOptions) {
       ALL_EMIT_BLOCK_KINDS,
     ),
     useSimpleInputs: parseStringBoolean(generatorConfig.useSimpleInputs),
+    emitRedundantDecoratorArgs: parseStringBoolean(
+      generatorConfig.emitRedundantDecoratorArgs,
+    ),
     customPrismaImportPath: generatorConfig.customPrismaImportPath,
     contextPrismaKey: generatorConfig.contextPrismaKey,
   };

--- a/src/cli/prisma-generator.ts
+++ b/src/cli/prisma-generator.ts
@@ -43,7 +43,7 @@ export async function generate(options: GeneratorOptions) {
       ALL_EMIT_BLOCK_KINDS,
     ),
     useSimpleInputs: parseStringBoolean(generatorConfig.useSimpleInputs),
-    emitRedundantDecoratorArgs: parseStringBoolean(
+    emitRedundantTypesInfo: parseStringBoolean(
       generatorConfig.emitRedundantDecoratorArgs,
     ),
     customPrismaImportPath: generatorConfig.customPrismaImportPath,

--- a/src/generator/generate-code.ts
+++ b/src/generator/generate-code.ts
@@ -254,6 +254,7 @@ export default async function generateCode(
         baseDirPath,
         dmmfDocument,
         relationModel,
+        options,
       ),
     );
     const relationResolversBarrelExportSourceFile = project.createSourceFile(
@@ -360,6 +361,7 @@ export default async function generateCode(
         mapping,
         model,
         dmmfDocument,
+        options,
       );
       mapping.actions.forEach(async action => {
         const model = dmmfDocument.datamodel.models.find(
@@ -372,6 +374,7 @@ export default async function generateCode(
           action,
           mapping,
           dmmfDocument,
+          options,
         );
       });
     });

--- a/src/generator/options.ts
+++ b/src/generator/options.ts
@@ -8,6 +8,7 @@ export interface ExternalGeneratorOptions {
   useUncheckedScalarInputs?: boolean;
   emitIdAsIDType?: boolean;
   emitOnly?: EmitBlockKind[];
+  emitRedundantDecoratorArgs?: boolean;
   customPrismaImportPath?: string;
   contextPrismaKey?: string;
   useSimpleInputs?: boolean;

--- a/src/generator/options.ts
+++ b/src/generator/options.ts
@@ -8,7 +8,7 @@ export interface ExternalGeneratorOptions {
   useUncheckedScalarInputs?: boolean;
   emitIdAsIDType?: boolean;
   emitOnly?: EmitBlockKind[];
-  emitRedundantDecoratorArgs?: boolean;
+  emitRedundantTypesInfo?: boolean;
   customPrismaImportPath?: string;
   contextPrismaKey?: string;
   useSimpleInputs?: boolean;

--- a/src/generator/resolvers/full-crud.ts
+++ b/src/generator/resolvers/full-crud.ts
@@ -13,6 +13,7 @@ import {
 import { generateCrudResolverClassMethodDeclaration } from "./helpers";
 import { DmmfDocument } from "../dmmf/dmmf-document";
 import { DMMF } from "../dmmf/types";
+import { GeneratorOptions } from "../options";
 
 export default function generateCrudResolverClassFromMapping(
   project: Project,
@@ -20,6 +21,7 @@ export default function generateCrudResolverClassFromMapping(
   mapping: DMMF.ModelMapping,
   model: DMMF.Model,
   dmmfDocument: DmmfDocument,
+  generatorOptions: GeneratorOptions,
 ) {
   const resolverDirPath = path.resolve(
     baseDirPath,
@@ -70,6 +72,7 @@ export default function generateCrudResolverClassFromMapping(
           action,
           mapping,
           dmmfDocument,
+          generatorOptions,
         ),
     ),
   });

--- a/src/generator/resolvers/helpers.ts
+++ b/src/generator/resolvers/helpers.ts
@@ -46,7 +46,7 @@ export function generateCrudResolverClassMethodDeclaration(
               decorators: [
                 {
                   name: "TypeGraphQL.Args",
-                  arguments: generatorOptions.emitRedundantDecoratorArgs
+                  arguments: generatorOptions.emitRedundantTypesInfo
                     ? [`_returns => ${action.argsTypeName}`]
                     : [],
                 },

--- a/src/generator/resolvers/helpers.ts
+++ b/src/generator/resolvers/helpers.ts
@@ -48,7 +48,7 @@ export function generateCrudResolverClassMethodDeclaration(
                   name: "TypeGraphQL.Args",
                   arguments: generatorOptions.emitRedundantDecoratorArgs
                     ? [`_returns => ${action.argsTypeName}`]
-                    : undefined,
+                    : [],
                 },
               ],
             },

--- a/src/generator/resolvers/helpers.ts
+++ b/src/generator/resolvers/helpers.ts
@@ -2,11 +2,13 @@ import { OptionalKind, MethodDeclarationStructure, Writers } from "ts-morph";
 
 import { DmmfDocument } from "../dmmf/dmmf-document";
 import { DMMF } from "../dmmf/types";
+import { GeneratorOptions } from "../options";
 
 export function generateCrudResolverClassMethodDeclaration(
   action: DMMF.Action,
   mapping: DMMF.ModelMapping,
   dmmfDocument: DmmfDocument,
+  generatorOptions: GeneratorOptions,
 ): OptionalKind<MethodDeclarationStructure> {
   return {
     name: action.name,
@@ -41,7 +43,14 @@ export function generateCrudResolverClassMethodDeclaration(
             {
               name: "args",
               type: action.argsTypeName,
-              decorators: [{ name: "TypeGraphQL.Args", arguments: [] }],
+              decorators: [
+                {
+                  name: "TypeGraphQL.Args",
+                  arguments: generatorOptions.emitRedundantDecoratorArgs
+                    ? [`_returns => ${action.argsTypeName}`]
+                    : undefined,
+                },
+              ],
             },
           ]),
     ],

--- a/src/generator/resolvers/relations.ts
+++ b/src/generator/resolvers/relations.ts
@@ -138,7 +138,7 @@ export default function generateRelationsResolverClassesFromModel(
                     decorators: [
                       {
                         name: "TypeGraphQL.Args",
-                        arguments: generatorOptions.emitRedundantDecoratorArgs
+                        arguments: generatorOptions.emitRedundantTypesInfo
                           ? [`_returns => ${field.argsTypeName}`]
                           : [],
                       },

--- a/src/generator/resolvers/relations.ts
+++ b/src/generator/resolvers/relations.ts
@@ -16,12 +16,14 @@ import {
 } from "../imports";
 import { DmmfDocument } from "../dmmf/dmmf-document";
 import { DMMF } from "../dmmf/types";
+import { GeneratorOptions } from "../options";
 
 export default function generateRelationsResolverClassesFromModel(
   project: Project,
   baseDirPath: string,
   dmmfDocument: DmmfDocument,
   { model, relationFields, resolverName }: DMMF.RelationModel,
+  generatorOptions: GeneratorOptions,
 ) {
   const rootArgName = camelCase(model.typeName);
   const singleIdField = model.fields.find(field => field.isId);
@@ -133,7 +135,14 @@ export default function generateRelationsResolverClassesFromModel(
                   {
                     name: "args",
                     type: field.argsTypeName,
-                    decorators: [{ name: "TypeGraphQL.Args", arguments: [] }],
+                    decorators: [
+                      {
+                        name: "TypeGraphQL.Args",
+                        arguments: generatorOptions.emitRedundantDecoratorArgs
+                          ? [`_returns => ${field.argsTypeName}`]
+                          : undefined,
+                      },
+                    ],
                   },
                 ]),
           ],

--- a/src/generator/resolvers/relations.ts
+++ b/src/generator/resolvers/relations.ts
@@ -140,7 +140,7 @@ export default function generateRelationsResolverClassesFromModel(
                         name: "TypeGraphQL.Args",
                         arguments: generatorOptions.emitRedundantDecoratorArgs
                           ? [`_returns => ${field.argsTypeName}`]
-                          : undefined,
+                          : [],
                       },
                     ],
                   },

--- a/src/generator/resolvers/separate-action.ts
+++ b/src/generator/resolvers/separate-action.ts
@@ -13,6 +13,7 @@ import {
 import { generateCrudResolverClassMethodDeclaration } from "./helpers";
 import { DmmfDocument } from "../dmmf/dmmf-document";
 import { DMMF } from "../dmmf/types";
+import { GeneratorOptions } from "../options";
 
 export default function generateActionResolverClass(
   project: Project,
@@ -21,6 +22,7 @@ export default function generateActionResolverClass(
   action: DMMF.Action,
   mapping: DMMF.ModelMapping,
   dmmfDocument: DmmfDocument,
+  generatorOptions: GeneratorOptions,
 ) {
   const sourceFile = project.createSourceFile(
     path.resolve(
@@ -65,7 +67,12 @@ export default function generateActionResolverClass(
       },
     ],
     methods: [
-      generateCrudResolverClassMethodDeclaration(action, mapping, dmmfDocument),
+      generateCrudResolverClassMethodDeclaration(
+        action,
+        mapping,
+        dmmfDocument,
+        generatorOptions,
+      ),
     ],
   });
 }


### PR DESCRIPTION
Added option `emitRedundantDecoratorArgs` to generator config to add some redundant type definition as suggested in https://github.com/MichalLytek/typegraphql-prisma/issues/277

Not sure if passing this option to the respective functions is the right way.
Also I had to add `ts-toolbelt` as a devDep otherwise local build would fail for me.

Would be really awesome if you let me know if there is a chance of merging this or of having this feature otherwise in the near future. 
Thanks :) 