### PR TITLE
Fix issue with isolated modules in SWC

### DIFF
--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -34,6 +34,7 @@ export function generateGraphQLFieldsImport(sourceFile: SourceFile) {
   });
   sourceFile.addImportDeclaration({
     moduleSpecifier: "graphql",
+    isTypeOnly: true,
     namedImports: ["GraphQLResolveInfo"],
   });
 }


### PR DESCRIPTION
# Description

When using generated resolvers with TypeScript isolated modules enabled, we get the following error during next build (probably due to swc):

```
A type referenced in a decorated signature must be imported with 'import type' or a namespace import when 'isolatedModules' and 'emitDecoratorMetadata' are enabled
```

Because of a full import of `GraphQLResolveInfo` from `graphql`.

# How it was solved

When using `import type`, the isolated modules constraint is preserved. This PR changes the imports generator to generate type imports for GraphQL.
