### PR TITLE
Update usage.md to include the apollo-serve v4

### DIFF
--- a/docs/basics/usage.md
+++ b/docs/basics/usage.md
@@ -228,3 +228,7 @@ const server = new ApolloServer({
   context: () => ({ prisma }),
 });
 ```
+
+:::caution
+Be aware that depending on apollo-version installed you might need to pass the `context` function to `startStandaloneServer`. You can read more about it in the [Migrating to Apollo Server 4](https://www.apollographql.com/docs/apollo-server/migration/#migrate-from-apollo-server) guide.
+:::


### PR DESCRIPTION
With apollo-server v4, the way to pass context changed. 

```ts
const server = new ApolloServer<MyContext>({ typeDefs, resolvers });
const { url } = await startStandaloneServer(server, {
  context: async ({ req }) => ({ token: req.headers.token }),
  listen: { port: 4000 },
});
console.log(`🚀  Server ready at ${url}`);
```