### PR TITLE
Support generating ESM output

### DIFF
--- a/src/cli/prisma-generator.ts
+++ b/src/cli/prisma-generator.ts
@@ -68,6 +68,7 @@ export async function generate(options: GeneratorOptions) {
         ["prettier", "tsc"] as const,
       ),
     emitIsAbstract: parseStringBoolean(generatorConfig.emitIsAbstract) ?? false,
+    emitESM: parseStringBoolean(generatorConfig.emitESM),
   };
   const internalConfig: InternalGeneratorOptions = {
     outputDirPath: outputDir,

--- a/src/generator/args-class.ts
+++ b/src/generator/args-class.ts
@@ -34,6 +34,7 @@ export default function generateArgsTypeClassFromArgs(
   generateGraphQLScalarsImport(sourceFile);
   generateInputsImports(
     sourceFile,
+    dmmfDocument.options,
     fields
       .map(arg => arg.selectedInputType)
       .filter(argInputType => argInputType.location === "inputObjectTypes")
@@ -42,6 +43,7 @@ export default function generateArgsTypeClassFromArgs(
   );
   generateEnumsImports(
     sourceFile,
+    dmmfDocument.options,
     fields
       .map(field => field.selectedInputType)
       .filter(argType => argType.location === "enumTypes")

--- a/src/generator/generate-enhance.ts
+++ b/src/generator/generate-enhance.ts
@@ -42,11 +42,15 @@ export function generateEnhanceMap(
 
   if (dmmfDocument.shouldGenerateBlock("crudResolvers")) {
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-crud.index`,
+      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-crud.index${
+        dmmfDocument.options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "crudResolvers",
     });
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/args.index`,
+      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/args.index${
+        dmmfDocument.options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "argsTypes",
     });
     sourceFile.addVariableStatement({
@@ -67,7 +71,9 @@ export function generateEnhanceMap(
       trailingTrivia: "\r\n",
     });
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-actions.index`,
+      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-actions.index${
+        dmmfDocument.options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "actionResolvers",
     });
     sourceFile.addVariableStatement({
@@ -237,7 +243,9 @@ export function generateEnhanceMap(
 
   if (hasRelations && dmmfDocument.shouldGenerateBlock("relationResolvers")) {
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}/resolvers.index`,
+      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}/resolvers.index${
+        dmmfDocument.options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "relationResolvers",
     });
     sourceFile.addVariableStatement({
@@ -367,7 +375,9 @@ export function generateEnhanceMap(
 
   if (dmmfDocument.shouldGenerateBlock("models")) {
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${modelsFolderName}`,
+      moduleSpecifier: `./${modelsFolderName}${
+        dmmfDocument.options.emitESM ? "/index.js" : ""
+      }`,
       namespaceImport: "models",
     });
     sourceFile.addVariableStatement({
@@ -435,7 +445,9 @@ export function generateEnhanceMap(
 
   if (dmmfDocument.shouldGenerateBlock("outputs")) {
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${outputsFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${outputsFolderName}${
+        dmmfDocument.options.emitESM ? "/index.js" : ""
+      }`,
       namespaceImport: "outputTypes",
     });
     sourceFile.addVariableStatement({
@@ -497,7 +509,9 @@ export function generateEnhanceMap(
 
   if (dmmfDocument.shouldGenerateBlock("inputs")) {
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${inputsFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${inputsFolderName}${
+        dmmfDocument.options.emitESM ? "/index.js" : ""
+      }`,
       namespaceImport: "inputTypes",
     });
     sourceFile.addVariableStatement({

--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -56,20 +56,34 @@ export function generateGraphQLScalarTypeImport(sourceFile: SourceFile) {
   });
 }
 
-export function generateCustomScalarsImport(sourceFile: SourceFile, level = 0) {
+export function generateCustomScalarsImport(
+  sourceFile: SourceFile,
+  options: GeneratorOptions,
+  level = 0,
+) {
   sourceFile.addImportDeclaration({
     moduleSpecifier:
       (level === 0 ? "./" : "") +
-      path.posix.join(...Array(level).fill(".."), "scalars"),
+      path.posix.join(
+        ...Array(level).fill(".."),
+        `scalars${options.emitESM ? ".js" : ""}`,
+      ),
     namedImports: ["DecimalJSScalar"],
   });
 }
 
-export function generateHelpersFileImport(sourceFile: SourceFile, level = 0) {
+export function generateHelpersFileImport(
+  sourceFile: SourceFile,
+  options: GeneratorOptions,
+  level = 0,
+) {
   sourceFile.addImportDeclaration({
     moduleSpecifier:
       (level === 0 ? "./" : "") +
-      path.posix.join(...Array(level).fill(".."), "helpers"),
+      path.posix.join(
+        ...Array(level).fill(".."),
+        `helpers${options.emitESM ? ".js" : ""}`,
+      ),
     namedImports: [
       "transformInfoIntoPrismaArgs",
       "getPrismaFromContext",
@@ -97,13 +111,14 @@ export function generatePrismaNamespaceImport(
 
 export function generateArgsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   argsTypeNames: string[],
 ) {
   sourceFile.addExportDeclarations(
     argsTypeNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(argTypeName => ({
-        moduleSpecifier: `./${argTypeName}`,
+        moduleSpecifier: `./${argTypeName}${options.emitESM ? ".js" : ""}`,
         namedExports: [argTypeName],
       })),
   );
@@ -111,26 +126,30 @@ export function generateArgsBarrelFile(
 
 export function generateArgsIndexFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   typeNames: string[],
 ) {
   sourceFile.addExportDeclarations(
     typeNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(typeName => ({
-        moduleSpecifier: `./${typeName}/args`,
+        moduleSpecifier: `./${typeName}/args${
+          options.emitESM ? "/index.js" : ""
+        }`,
       })),
   );
 }
 
 export function generateModelsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   modelNames: string[],
 ) {
   sourceFile.addExportDeclarations(
     modelNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(modelName => ({
-        moduleSpecifier: `./${modelName}`,
+        moduleSpecifier: `./${modelName}${options.emitESM ? ".js" : ""}`,
         namedExports: [modelName],
       })),
   );
@@ -138,13 +157,14 @@ export function generateModelsBarrelFile(
 
 export function generateEnumsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   enumTypeNames: string[],
 ) {
   sourceFile.addExportDeclarations(
     enumTypeNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(enumTypeName => ({
-        moduleSpecifier: `./${enumTypeName}`,
+        moduleSpecifier: `./${enumTypeName}${options.emitESM ? ".js" : ""}`,
         namedExports: [enumTypeName],
       })),
   );
@@ -152,13 +172,14 @@ export function generateEnumsBarrelFile(
 
 export function generateInputsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   inputTypeNames: string[],
 ) {
   sourceFile.addExportDeclarations(
     inputTypeNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(inputTypeName => ({
-        moduleSpecifier: `./${inputTypeName}`,
+        moduleSpecifier: `./${inputTypeName}${options.emitESM ? ".js" : ""}`,
         namedExports: [inputTypeName],
       })),
   );
@@ -166,6 +187,7 @@ export function generateInputsBarrelFile(
 
 export function generateOutputsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   outputTypeNames: string[],
   hasSomeArgs: boolean,
 ) {
@@ -173,7 +195,7 @@ export function generateOutputsBarrelFile(
     outputTypeNames
       .sort()
       .map<OptionalKind<ExportDeclarationStructure>>(outputTypeName => ({
-        moduleSpecifier: `./${outputTypeName}`,
+        moduleSpecifier: `./${outputTypeName}${options.emitESM ? ".js" : ""}`,
         namedExports: [outputTypeName],
       })),
   );
@@ -184,25 +206,34 @@ export function generateOutputsBarrelFile(
 
 export function generateIndexFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   hasSomeRelations: boolean,
   blocksToEmit: EmitBlockKind[],
 ) {
   if (blocksToEmit.includes("enums")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${enumsFolderName}`,
+      moduleSpecifier: `./${enumsFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
   }
   if (blocksToEmit.includes("models")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${modelsFolderName}`,
+      moduleSpecifier: `./${modelsFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
   }
   if (blocksToEmit.includes("crudResolvers")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-crud.index`,
+      moduleSpecifier: `./${resolversFolderName}/${crudResolversFolderName}/resolvers-crud.index${
+        options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "crudResolversImport",
     });
     sourceFile.addVariableStatement({
@@ -212,16 +243,21 @@ export function generateIndexFile(
         {
           name: "crudResolvers",
           initializer: `Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>`,
+          type: "NonEmptyArray<Function>",
         },
       ],
     });
   }
   if (hasSomeRelations && blocksToEmit.includes("relationResolvers")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
     sourceFile.addImportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}/resolvers.index`,
+      moduleSpecifier: `./${resolversFolderName}/${relationsResolversFolderName}/resolvers.index${
+        options.emitESM ? ".js" : ""
+      }`,
       namespaceImport: "relationResolversImport",
     });
     sourceFile.addVariableStatement({
@@ -231,24 +267,29 @@ export function generateIndexFile(
         {
           name: "relationResolvers",
           initializer: `Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>`,
+          type: "NonEmptyArray<Function>",
         },
       ],
     });
   }
   if (blocksToEmit.includes("inputs")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${inputsFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${inputsFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
   }
   if (blocksToEmit.includes("outputs")) {
     sourceFile.addExportDeclaration({
-      moduleSpecifier: `./${resolversFolderName}/${outputsFolderName}`,
+      moduleSpecifier: `./${resolversFolderName}/${outputsFolderName}${
+        options.emitESM ? "/index.js" : ""
+      }`,
     });
   }
 
   sourceFile.addExportDeclarations([
-    { moduleSpecifier: `./enhance` },
-    { moduleSpecifier: `./scalars` },
+    { moduleSpecifier: `./enhance${options.emitESM ? ".js" : ""}` },
+    { moduleSpecifier: `./scalars${options.emitESM ? ".js" : ""}` },
   ]);
   sourceFile.addImportDeclarations([
     {
@@ -282,6 +323,7 @@ export function generateIndexFile(
 
 export function generateResolversBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   resolversData: GenerateMappingData[],
 ) {
   resolversData
@@ -290,13 +332,16 @@ export function generateResolversBarrelFile(
     )
     .forEach(({ modelName, resolverName }) => {
       sourceFile.addExportDeclaration({
-        moduleSpecifier: `./${modelName}/${resolverName}`,
+        moduleSpecifier: `./${modelName}/${resolverName}${
+          options.emitESM ? ".js" : ""
+        }`,
         namedExports: [resolverName],
       });
     });
 }
 export function generateResolversActionsBarrelFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   resolversData: GenerateMappingData[],
 ) {
   resolversData
@@ -307,7 +352,9 @@ export function generateResolversActionsBarrelFile(
       if (actionResolverNames) {
         actionResolverNames.forEach(actionResolverName => {
           sourceFile.addExportDeclaration({
-            moduleSpecifier: `./${modelName}/${actionResolverName}`,
+            moduleSpecifier: `./${modelName}/${actionResolverName}${
+              options.emitESM ? ".js" : ""
+            }`,
             namedExports: [actionResolverName],
           });
         });
@@ -317,21 +364,32 @@ export function generateResolversActionsBarrelFile(
 
 export function generateResolversIndexFile(
   sourceFile: SourceFile,
+  options: GeneratorOptions,
   type: "crud" | "relations",
   hasSomeArgs: boolean,
 ) {
   if (type === "crud") {
     sourceFile.addExportDeclarations([
-      { moduleSpecifier: `./resolvers-actions.index` },
-      { moduleSpecifier: `./resolvers-crud.index` },
+      {
+        moduleSpecifier: `./resolvers-actions.index${
+          options.emitESM ? ".js" : ""
+        }`,
+      },
+      {
+        moduleSpecifier: `./resolvers-crud.index${
+          options.emitESM ? ".js" : ""
+        }`,
+      },
     ]);
   } else {
     sourceFile.addExportDeclarations([
-      { moduleSpecifier: `./resolvers.index` },
+      { moduleSpecifier: `./resolvers.index${options.emitESM ? ".js" : ""}` },
     ]);
   }
   if (hasSomeArgs) {
-    sourceFile.addExportDeclarations([{ moduleSpecifier: `./args.index` }]);
+    sourceFile.addExportDeclarations([
+      { moduleSpecifier: `./args.index${options.emitESM ? ".js" : ""}` },
+    ]);
   }
 }
 
@@ -345,7 +403,12 @@ export const generateResolversOutputsImports = createImportGenerator(
 );
 export const generateArgsImports = createImportGenerator(argsFolderName);
 function createImportGenerator(elementsDirName: string) {
-  return (sourceFile: SourceFile, elementsNames: string[], level = 1) => {
+  return (
+    sourceFile: SourceFile,
+    options: GeneratorOptions,
+    elementsNames: string[],
+    level = 1,
+  ) => {
     const distinctElementsNames = [...new Set(elementsNames)].sort();
     for (const elementName of distinctElementsNames) {
       sourceFile.addImportDeclaration({
@@ -354,7 +417,7 @@ function createImportGenerator(elementsDirName: string) {
           path.posix.join(
             ...Array(level).fill(".."),
             elementsDirName,
-            elementName,
+            `${elementName}${options.emitESM ? ".js" : ""}`,
           ),
         // TODO: refactor to default exports
         // defaultImport: elementName,

--- a/src/generator/model-type-class.ts
+++ b/src/generator/model-type-class.ts
@@ -37,9 +37,10 @@ export default function generateObjectTypeClassFromModel(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, dmmfDocument.options, 1);
-  generateCustomScalarsImport(sourceFile, 1);
+  generateCustomScalarsImport(sourceFile, dmmfDocument.options, 1);
   generateModelsImports(
     sourceFile,
+    dmmfDocument.options,
     model.fields
       .filter(field => field.location === "outputObjectTypes")
       .filter(field => field.type !== model.name)
@@ -51,6 +52,7 @@ export default function generateObjectTypeClassFromModel(
   );
   generateEnumsImports(
     sourceFile,
+    dmmfDocument.options,
     model.fields
       .filter(field => field.location === "enumTypes")
       .map(field => field.type),
@@ -61,7 +63,9 @@ export default function generateObjectTypeClassFromModel(
     countField !== undefined &&
     dmmfDocument.shouldGenerateBlock("crudResolvers");
   if (shouldEmitCountField) {
-    generateResolversOutputsImports(sourceFile, [countField.typeGraphQLType]);
+    generateResolversOutputsImports(sourceFile, dmmfDocument.options, [
+      countField.typeGraphQLType,
+    ]);
   }
 
   sourceFile.addClass({

--- a/src/generator/options.ts
+++ b/src/generator/options.ts
@@ -16,6 +16,7 @@ export interface ExternalGeneratorOptions {
   omitOutputFieldsByDefault?: string[];
   formatGeneratedCode?: boolean | "prettier" | "tsc";
   emitIsAbstract?: boolean;
+  emitESM?: boolean;
 }
 
 export interface InternalGeneratorOptions {

--- a/src/generator/resolvers/full-crud.ts
+++ b/src/generator/resolvers/full-crud.ts
@@ -38,12 +38,13 @@ export default function generateCrudResolverClassFromMapping(
   generateGraphQLInfoImport(sourceFile);
   generateArgsImports(
     sourceFile,
+    dmmfDocument.options,
     mapping.actions
       .filter(it => it.argsTypeName !== undefined)
       .map(it => it.argsTypeName!),
     0,
   );
-  generateHelpersFileImport(sourceFile, 3);
+  generateHelpersFileImport(sourceFile, dmmfDocument.options, 3);
 
   const distinctOutputTypesNames = [
     ...new Set(mapping.actions.map(it => it.outputTypeName)),
@@ -54,8 +55,18 @@ export default function generateCrudResolverClassFromMapping(
   const otherOutputTypeNames = distinctOutputTypesNames.filter(
     typeName => !dmmfDocument.isModelTypeName(typeName),
   );
-  generateModelsImports(sourceFile, modelOutputTypeNames, 3);
-  generateOutputsImports(sourceFile, otherOutputTypeNames, 2);
+  generateModelsImports(
+    sourceFile,
+    dmmfDocument.options,
+    modelOutputTypeNames,
+    3,
+  );
+  generateOutputsImports(
+    sourceFile,
+    dmmfDocument.options,
+    otherOutputTypeNames,
+    2,
+  );
 
   sourceFile.addClass({
     name: mapping.resolverName,

--- a/src/generator/resolvers/relations.ts
+++ b/src/generator/resolvers/relations.ts
@@ -57,6 +57,7 @@ export default function generateRelationsResolverClassesFromModel(
   generateGraphQLInfoImport(sourceFile);
   generateModelsImports(
     sourceFile,
+    dmmfDocument.options,
     [...relationFields.map(field => field.type), model.typeName],
     3,
   );
@@ -64,8 +65,8 @@ export default function generateRelationsResolverClassesFromModel(
   const argTypeNames = relationFields
     .filter(it => it.argsTypeName !== undefined)
     .map(it => it.argsTypeName!);
-  generateArgsImports(sourceFile, argTypeNames, 0);
-  generateHelpersFileImport(sourceFile, 3);
+  generateArgsImports(sourceFile, dmmfDocument.options, argTypeNames, 0);
+  generateHelpersFileImport(sourceFile, dmmfDocument.options, 3);
 
   sourceFile.addClass({
     name: resolverName,

--- a/src/generator/resolvers/separate-action.ts
+++ b/src/generator/resolvers/separate-action.ts
@@ -39,10 +39,16 @@ export default function generateActionResolverClass(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLInfoImport(sourceFile);
   if (action.argsTypeName) {
-    generateArgsImports(sourceFile, [action.argsTypeName], 0);
+    generateArgsImports(
+      sourceFile,
+      dmmfDocument.options,
+      [action.argsTypeName],
+      0,
+    );
   }
   generateModelsImports(
     sourceFile,
+    dmmfDocument.options,
     [model.typeName, action.outputTypeName].filter(typeName =>
       dmmfDocument.isModelTypeName(typeName),
     ),
@@ -50,12 +56,13 @@ export default function generateActionResolverClass(
   );
   generateOutputsImports(
     sourceFile,
+    dmmfDocument.options,
     [action.outputTypeName].filter(
       typeName => !dmmfDocument.isModelTypeName(typeName),
     ),
     2,
   );
-  generateHelpersFileImport(sourceFile, 3);
+  generateHelpersFileImport(sourceFile, dmmfDocument.options, 3);
 
   sourceFile.addClass({
     name: action.actionResolverName,

--- a/src/generator/type-class.ts
+++ b/src/generator/type-class.ts
@@ -43,10 +43,11 @@ export function generateOutputTypeClassFromType(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, dmmfDocument.options, 2);
-  generateCustomScalarsImport(sourceFile, 2);
-  generateArgsImports(sourceFile, fieldArgsTypeNames, 0);
+  generateCustomScalarsImport(sourceFile, dmmfDocument.options, 2);
+  generateArgsImports(sourceFile, dmmfDocument.options, fieldArgsTypeNames, 0);
   generateOutputsImports(
     sourceFile,
+    dmmfDocument.options,
     type.fields
       .filter(field => field.outputType.location === "outputObjectTypes")
       .map(field => field.outputType.type),
@@ -54,6 +55,7 @@ export function generateOutputTypeClassFromType(
   );
   generateEnumsImports(
     sourceFile,
+    dmmfDocument.options,
     type.fields
       .map(field => field.outputType)
       .filter(fieldType => fieldType.location === "enumTypes")
@@ -163,9 +165,10 @@ export function generateInputTypeClassFromType(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, options, 2);
-  generateCustomScalarsImport(sourceFile, 2);
+  generateCustomScalarsImport(sourceFile, options, 2);
   generateInputsImports(
     sourceFile,
+    options,
     inputType.fields
       .filter(field => field.selectedInputType.location === "inputObjectTypes")
       .map(field => field.selectedInputType.type)
@@ -173,6 +176,7 @@ export function generateInputTypeClassFromType(
   );
   generateEnumsImports(
     sourceFile,
+    options,
     inputType.fields
       .map(field => field.selectedInputType)
       .filter(fieldType => fieldType.location === "enumTypes")

--- a/tests/regression/__snapshots__/crud.ts.snap
+++ b/tests/regression/__snapshots__/crud.ts.snap
@@ -1282,7 +1282,7 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";

--- a/tests/regression/__snapshots__/emit-only.ts.snap
+++ b/tests/regression/__snapshots__/emit-only.ts.snap
@@ -444,7 +444,7 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";
@@ -1093,7 +1093,7 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";
@@ -2170,7 +2170,7 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/relations\\";
 
-export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
+export const relationResolvers: NonEmptyArray<Function> = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./enhance\\";

--- a/tests/regression/__snapshots__/enhance.ts.snap
+++ b/tests/regression/__snapshots__/enhance.ts.snap
@@ -493,11 +493,11 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/relations\\";
 
-export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
+export const relationResolvers: NonEmptyArray<Function> = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";

--- a/tests/regression/__snapshots__/generate-scalars.ts.snap
+++ b/tests/regression/__snapshots__/generate-scalars.ts.snap
@@ -8,7 +8,7 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";

--- a/tests/regression/__snapshots__/relations.ts.snap
+++ b/tests/regression/__snapshots__/relations.ts.snap
@@ -48,11 +48,11 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/relations\\";
 
-export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
+export const relationResolvers: NonEmptyArray<Function> = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";
@@ -181,11 +181,11 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/relations\\";
 
-export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
+export const relationResolvers: NonEmptyArray<Function> = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";
@@ -225,11 +225,11 @@ export * from \\"./enums\\";
 export * from \\"./models\\";
 export * from \\"./resolvers/crud\\";
 
-export const crudResolvers = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
+export const crudResolvers: NonEmptyArray<Function> = Object.values(crudResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/relations\\";
 
-export const relationResolvers = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
+export const relationResolvers: NonEmptyArray<Function> = Object.values(relationResolversImport) as unknown as NonEmptyArray<Function>;
 
 export * from \\"./resolvers/inputs\\";
 export * from \\"./resolvers/outputs\\";


### PR DESCRIPTION
re: #372

Setting `emitESM=true` in the generator's configuration will switch from using `require` to `import` calls in the generated code.

I haven't been successful in actually using the ESM output. Bi-directional relationships between models lead to circular dependencies in `*WhereInput` and `*ListRelationFilter` and cause the following error at start-up:

> ReferenceError: Cannot access 'FooWhereInput' before initialization
>     at file:///app/node_modules/@generated/type-graphql/resolvers/inputs/FooListRelationFilter.js:10:31

Even without setting `emitESM=true`, changing imports to use filenames with extension makes Typescript with `moduleResolution=node16` stop complaining about missing types.