### PR TITLE
Lock Prisma deps and add npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/generator-helper": "^4.15.0",
-        "@prisma/internals": "^4.15.0",
+        "@prisma/generator-helper": "4.15.0",
+        "@prisma/internals": "4.15.0",
         "pluralize": "^8.0.0",
         "semver": "^7.5.2",
         "ts-morph": "^19.0.0",
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@jest/types": "^29.5.0",
-        "@prisma/client": "^4.15.0",
+        "@prisma/client": "4.15.0",
         "@types/graphql-fields": "^1.3.5",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
@@ -52,12 +52,12 @@
         "node": ">=12.4"
       },
       "peerDependencies": {
-        "@prisma/client": "^4.15.0",
+        "@prisma/client": "4.15.0",
         "@types/graphql-fields": "^1.3.5",
         "@types/node": "*",
         "graphql-fields": "^2.0.3",
         "graphql-scalars": "^1.22.2",
-        "prisma": "^4.15.0",
+        "prisma": "4.15.0",
         "tslib": "^2.5.3",
         "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta"
       }

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
     "typegraphql-prisma": "lib/generator.js"
   },
   "peerDependencies": {
-    "@prisma/client": "^4.15.0",
+    "@prisma/client": "4.15.0",
     "@types/graphql-fields": "^1.3.5",
     "@types/node": "*",
     "graphql-fields": "^2.0.3",
     "graphql-scalars": "^1.22.2",
-    "prisma": "^4.15.0",
+    "prisma": "4.15.0",
     "tslib": "^2.5.3",
     "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^4.15.0",
-    "@prisma/internals": "^4.15.0",
+    "@prisma/generator-helper": "4.15.0",
+    "@prisma/internals": "4.15.0",
     "pluralize": "^8.0.0",
     "semver": "^7.5.2",
     "ts-morph": "^19.0.0",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@jest/types": "^29.5.0",
-    "@prisma/client": "^4.15.0",
+    "@prisma/client": "4.15.0",
     "@types/graphql-fields": "^1.3.5",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",


### PR DESCRIPTION
This pull request does two things:
* Locks the version of Prisma dependencies to only be that of the currently supported Prisma version. Usage on versions other than the currently stated version will be at the implementor's own risk.
* Adds an `.npmrc` file to stop future dependencies from being added with a flexible dependency range. Going forward, new npm dependencies will not be installed with a leading `^` - their versions must be manually changed.

This PR resolves https://github.com/MichalLytek/typegraphql-prisma/issues/397