### PR TITLE
fix: fields with undefined values present in args of generated types

### DIFF
--- a/src/generator/generate-code.ts
+++ b/src/generator/generate-code.ts
@@ -59,6 +59,7 @@ const baseCompilerOptions: CompilerOptions = {
   experimentalDecorators: true,
   esModuleInterop: true,
   skipLibCheck: true,
+  useDefineForClassFields: false,
 };
 
 export default async function generateCode(

--- a/tests/functional/__snapshots__/crud.ts.snap
+++ b/tests/functional/__snapshots__/crud.ts.snap
@@ -56,32 +56,17 @@ Array [
         "floatField": true,
         "intField": true,
       },
-      "cursor": undefined,
       "orderBy": Array [
         UserOrderByWithRelationInput {
-          "floatField": undefined,
-          "idField": undefined,
           "intField": "desc",
         },
       ],
       "skip": 1,
       "take": 1,
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "floatField": IntFilter {
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
           "lte": 50,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "idField": undefined,
-        "intField": undefined,
       },
     },
   ],
@@ -105,32 +90,17 @@ Array [
       "_count": Object {
         "_all": true,
       },
-      "cursor": undefined,
       "orderBy": Array [
         UserOrderByWithRelationInput {
-          "floatField": undefined,
-          "idField": undefined,
           "intField": "desc",
         },
       ],
       "skip": 1,
       "take": 1,
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "floatField": IntFilter {
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
           "lte": 50,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "idField": undefined,
-        "intField": undefined,
       },
     },
   ],
@@ -171,26 +141,10 @@ Array [
       "by": Array [
         "intField",
       ],
-      "having": undefined,
-      "orderBy": undefined,
-      "skip": undefined,
-      "take": undefined,
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "floatField": IntFilter {
-          "equals": undefined,
-          "gt": undefined,
           "gte": 0,
-          "in": undefined,
-          "lt": undefined,
-          "lte": undefined,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "idField": undefined,
-        "intField": undefined,
       },
     },
   ],
@@ -201,8 +155,6 @@ exports[`crud resolvers execution basic operations _count for relations should p
 Array [
   Array [
     Object {
-      "cursor": undefined,
-      "distinct": undefined,
       "include": Object {
         "_count": Object {
           "select": Object {
@@ -210,10 +162,6 @@ Array [
           },
         },
       },
-      "orderBy": undefined,
-      "skip": undefined,
-      "take": undefined,
-      "where": undefined,
     },
   ],
 ]
@@ -258,12 +206,6 @@ Array [
   Array [
     Object {
       "where": UserWhereUniqueInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "dateField": undefined,
-        "intIdField": undefined,
-        "optionalStringField": undefined,
         "uniqueStringField": "unique",
       },
     },
@@ -285,22 +227,9 @@ Array [
   Array [
     Object {
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "dateField": DateTimeFilter {
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
           "lte": 2019-12-31T19:16:02.572Z,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "intIdField": undefined,
-        "optionalStringField": undefined,
-        "uniqueStringField": undefined,
       },
     },
   ],
@@ -319,35 +248,17 @@ exports[`crud resolvers execution basic operations should properly call PrismaCl
 Array [
   Array [
     Object {
-      "cursor": undefined,
-      "distinct": undefined,
       "orderBy": Array [
         UserOrderByWithRelationInput {
-          "dateField": undefined,
           "intIdField": "desc",
-          "optionalStringField": undefined,
-          "uniqueStringField": undefined,
         },
       ],
       "skip": 1,
       "take": 1,
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "dateField": DateTimeFilter {
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
           "lte": 2019-12-31T19:16:02.572Z,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "intIdField": undefined,
-        "optionalStringField": undefined,
-        "uniqueStringField": undefined,
       },
     },
   ],
@@ -370,12 +281,6 @@ Array [
   Array [
     Object {
       "where": UserWhereUniqueInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "dateField": undefined,
-        "intIdField": undefined,
-        "optionalStringField": undefined,
         "uniqueStringField": "uniqueValue",
       },
     },
@@ -400,16 +305,8 @@ Array [
         "dateField": DateTimeFieldUpdateOperationsInput {
           "set": 2019-12-31T14:16:02.572Z,
         },
-        "optionalStringField": undefined,
-        "uniqueStringField": undefined,
       },
       "where": UserWhereUniqueInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "dateField": undefined,
-        "intIdField": undefined,
-        "optionalStringField": undefined,
         "uniqueStringField": "unique",
       },
     },
@@ -431,27 +328,12 @@ Array [
   Array [
     Object {
       "data": UserUpdateManyMutationInput {
-        "dateField": undefined,
         "optionalStringField": null,
-        "uniqueStringField": undefined,
       },
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
         "dateField": DateTimeFilter {
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
           "lte": 2019-12-31T19:16:02.572Z,
-          "not": undefined,
-          "notIn": undefined,
         },
-        "intIdField": undefined,
-        "optionalStringField": undefined,
-        "uniqueStringField": undefined,
       },
     },
   ],
@@ -476,17 +358,9 @@ Array [
         "uniqueStringField": "unique",
       },
       "update": UserUpdateInput {
-        "dateField": undefined,
         "optionalStringField": null,
-        "uniqueStringField": undefined,
       },
       "where": UserWhereUniqueInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "dateField": undefined,
-        "intIdField": undefined,
-        "optionalStringField": undefined,
         "uniqueStringField": "unique",
       },
     },

--- a/tests/functional/__snapshots__/custom-resolvers.ts.snap
+++ b/tests/functional/__snapshots__/custom-resolvers.ts.snap
@@ -19,37 +19,17 @@ exports[`custom resolvers execution should be possible to use generated inputs, 
 Array [
   Array [
     FindManyPostArgs {
-      "cursor": undefined,
-      "distinct": undefined,
       "orderBy": Array [
         PostOrderByWithRelationInput {
           "color": "desc",
-          "content": undefined,
-          "uuid": undefined,
         },
       ],
       "skip": 1,
       "take": 1,
       "where": PostWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "color": undefined,
         "content": StringFilter {
-          "contains": undefined,
-          "endsWith": undefined,
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
-          "lte": undefined,
-          "mode": undefined,
-          "not": undefined,
-          "notIn": undefined,
           "startsWith": "Test",
         },
-        "uuid": undefined,
       },
     },
   ],

--- a/tests/functional/__snapshots__/reference-count.ts.snap
+++ b/tests/functional/__snapshots__/reference-count.ts.snap
@@ -4,8 +4,6 @@ exports[`relation counts querying should properly call PrismaClient on getting r
 Array [
   Array [
     Object {
-      "cursor": undefined,
-      "distinct": undefined,
       "include": Object {
         "_count": Object {
           "select": Object {
@@ -19,10 +17,6 @@ Array [
           },
         },
       },
-      "orderBy": undefined,
-      "skip": undefined,
-      "take": undefined,
-      "where": undefined,
     },
   ],
 ]

--- a/tests/functional/__snapshots__/relations.ts.snap
+++ b/tests/functional/__snapshots__/relations.ts.snap
@@ -110,33 +110,12 @@ exports[`relations resolvers execution single primary key should properly call P
 Array [
   Array [
     Object {
-      "cursor": undefined,
-      "distinct": undefined,
-      "orderBy": undefined,
       "skip": 1,
       "take": 1,
       "where": PostWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "author": undefined,
-        "authorId": undefined,
-        "color": undefined,
         "content": StringFilter {
-          "contains": undefined,
-          "endsWith": undefined,
-          "equals": undefined,
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
-          "lte": undefined,
-          "mode": undefined,
-          "not": undefined,
-          "notIn": undefined,
           "startsWith": "test",
         },
-        "uuid": undefined,
       },
     },
   ],

--- a/tests/functional/__snapshots__/renaming-fields.ts.snap
+++ b/tests/functional/__snapshots__/renaming-fields.ts.snap
@@ -4,30 +4,9 @@ exports[`crud resolvers execution should properly map aliased input field values
 Array [
   Array [
     Object {
-      "cursor": undefined,
-      "distinct": undefined,
-      "orderBy": undefined,
-      "skip": undefined,
-      "take": undefined,
       "where": UserWhereInput {
-        "AND": undefined,
-        "NOT": undefined,
-        "OR": undefined,
-        "dateOfBirth": undefined,
-        "id": undefined,
         "name": StringFilter {
-          "contains": undefined,
-          "endsWith": undefined,
           "equals": "John",
-          "gt": undefined,
-          "gte": undefined,
-          "in": undefined,
-          "lt": undefined,
-          "lte": undefined,
-          "mode": undefined,
-          "not": undefined,
-          "notIn": undefined,
-          "startsWith": undefined,
         },
       },
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "importHelpers": true,                    /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "useDefineForClassFields": false,         /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
fix for: https://github.com/MichalLytek/typegraphql-prisma/issues/434
---------

This restores the previous behavior of input keys only being set when specified by the api request via `variables`.

Unfortunately, this only guarantees a fix when `emitTranspiledCode = true` is used (the default). However, if `output = 'someDirOutsideOfNodeModules'` is used WITHOUT `emitTranspiledCode = true`, then the consuming app must do one of:
- target <= es2021
- specify `"useDefineForClassFields": false` if target == es2022

---------
[UseDefineForClassFields](https://www.typescriptlang.org/tsconfig#useDefineForClassFields)
`Default: true if [target](https://www.typescriptlang.org/tsconfig#target) is ES2022 or higher, including ESNext; false otherwise.`

| useDefineForClassFields | true | false |
| -- | -- | -- |
| ES2022 | [TS Playground](https://www.typescriptlang.org/play?strictPropertyInitialization=false&useDefineForClassFields=true&target=9#code/PTAEAEGcBcCcEsDG0AKsD2AHApraBPASQDt5p4BDAG3gC8Lz1iAuUAM2smwCgQIBXLgBFsbeMWwAxdLADCVCpEiT42KgBNIrOPx59w0CrADm2aK2yQATAAYrV7hIDuoRAqWghigBYAjdEbqoADe3KDhoMQUALbYrDAIxMZhEYhMCfzIMgAUAJQhKeEAvtxFeQDcQA) | [TS Playground](https://www.typescriptlang.org/play?strictPropertyInitialization=false&target=9&ssl=8&ssc=5&pln=1&pc=1&useDefineForClassFields=true#code/PTAEAEGcBcCcEsDG0AKsD2AHApraBPASQDt5p4BDAG3gC8Lz1iAuUAM2smwCgQIBXLgBFsbeMWwAxdLADCVCpEiT42KgBNIrDlS68w4aBVgBzbNFbZIAJgAM169wkB3UIgVLQQxQAsARujG6qAA3tygEaDEFAC22KwwCMQm4ZGITIn8yDIAFACUoakRAL7cxfkA3EA) |
| <= ES2021 | [TS Playground](https://www.typescriptlang.org/play?strictPropertyInitialization=false&useDefineForClassFields=true&target=8#code/PTAEAEGcBcCcEsDG0AKsD2AHApraBPASQDt5p4BDAG3gC8Lz1iAuUAM2smwCgQIBXLgBFsbeMWwAxdLADCVCpEiT42KgBNIrOPx59w0CrADm2aK2yQATAAYrARm4SA7qEQKloIYoAWAI3QjdVAAb25QCNBiCgBbbFYYBGJjcMjEJkT+ZBkACgBKUNSIgF9uYvyAbiA) | [TS Playground](https://www.typescriptlang.org/play?strictPropertyInitialization=false&target=8&useDefineForClassFields=true#code/PTAEAEGcBcCcEsDG0AKsD2AHApraBPASQDt5p4BDAG3gC8Lz1iAuUAM2smwCgQIBXLgBFsbeMWwAxdLADCVCpEiT42KgBNIrDlS68w4aBVgBzbNFbZIAJgAM1gIzcJAd1CIFS0EMUALAEboxuqgAN7coJGgxBQAttisMAjEJhFRiExJ-MgyABQAlGFpkQC+3CUFANxAA)

some interesting reading that pointed me in this direction:
https://github.com/swc-project/swc/pull/7055
https://github.com/microsoft/TypeScript/issues/45995