### PR TITLE
feat(resolvers): Allow enabling/disabling simpleResolvers per model

### DIFF
--- a/src/generator/dmmf/transform.ts
+++ b/src/generator/dmmf/transform.ts
@@ -54,6 +54,9 @@ export function transformBareModel(model: PrismaDMMF.Model): DMMF.Model {
     name: string;
     plural: string;
   }>(model.documentation, "type", "model");
+  const { enable } = parseDocumentationAttributes<{
+    enable?: boolean;
+  }>(model.documentation, "simpleResolvers", "model");
   const { output = false } = parseDocumentationAttributes<{
     output: boolean;
   }>(model.documentation, "omit", "model");
@@ -64,6 +67,7 @@ export function transformBareModel(model: PrismaDMMF.Model): DMMF.Model {
     docs: cleanDocsString(model.documentation),
     plural: attributeArgs.plural,
     isOmitted: { output },
+    simpleResolvers: { enable },
   };
 }
 

--- a/src/generator/dmmf/types.ts
+++ b/src/generator/dmmf/types.ts
@@ -45,6 +45,7 @@ export namespace DMMF {
     docs: string | undefined;
     plural: string | undefined;
     isOmitted: { output: boolean };
+    simpleResolvers: { enable?: boolean };
   }
   export type FieldKind = "scalar" | "object" | "enum" | "unsupported";
   export type FieldNamespace = "model" | "prisma";

--- a/src/generator/model-type-class.ts
+++ b/src/generator/model-type-class.ts
@@ -64,6 +64,11 @@ export default function generateObjectTypeClassFromModel(
     generateResolversOutputsImports(sourceFile, [countField.typeGraphQLType]);
   }
 
+  const shouldUseSimpleResolvers =
+    dmmfDocument.options.simpleResolvers
+      ? model.simpleResolvers.enable !== false
+      : model.simpleResolvers.enable;
+
   sourceFile.addClass({
     name: model.typeName,
     isExported: true,
@@ -79,9 +84,7 @@ export default function generateObjectTypeClassFromModel(
                   isAbstract: "true",
                 }),
                 ...(model.docs && { description: `"${model.docs}"` }),
-                ...(dmmfDocument.options.simpleResolvers && {
-                  simpleResolvers: "true",
-                }),
+                ...(shouldUseSimpleResolvers && { simpleResolvers: "true" }),
               }),
             ],
           },


### PR DESCRIPTION
Need to add tests, but before I do, @MichalLytek let me know if I'm on the right path. This change works locally.

Usage:
```
/// @@TypeGraphQL.simpleResolvers(enable: true)
model Employee {
}
```