### PR TITLE
Prisma 6 compatibility, with working tests (help required)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,12 +53,12 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@prisma/client": "^5.18.0 || ^6.0.0",
+        "@prisma/client": "^6.0.0",
         "@types/graphql-fields": "^1.3.9",
         "@types/node": "*",
         "graphql-fields": "^2.0.3",
         "graphql-scalars": "^1.23.0",
-        "prisma": "^5.18.0 || ^6.0.0",
+        "prisma": "^6.0.0",
         "tslib": "^2.6.3",
         "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/generator-helper": "^5.18.0",
-        "@prisma/internals": "^5.18.0",
+        "@prisma/generator-helper": "^6.3.1",
+        "@prisma/internals": "^6.3.1",
         "pluralize": "^8.0.0",
         "semver": "^7.6.3",
         "ts-morph": "^23.0.0",
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@jest/types": "^29.6.3",
-        "@prisma/client": "^5.18.0",
+        "@prisma/client": "^6.3.1",
         "@types/graphql-fields": "^1.3.9",
         "@types/jest": "^29.5.12",
         "@types/node": "^22.1.0",
@@ -40,7 +40,7 @@
         "pg": "^8.12.0",
         "prettier": "^3.3.3",
         "prettier-2": "npm:prettier@^2",
-        "prisma": "^5.18.0",
+        "prisma": "^6.3.1",
         "reflect-metadata": "0.1.13",
         "ts-jest": "~29.2.4",
         "ts-node": "^10.9.2",
@@ -53,12 +53,12 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@prisma/client": "^5.18.0",
+        "@prisma/client": "^5.18.0 || ^6.0.0",
         "@types/graphql-fields": "^1.3.9",
         "@types/node": "*",
         "graphql-fields": "^2.0.3",
         "graphql-scalars": "^1.23.0",
-        "prisma": "^5.18.0",
+        "prisma": "^5.18.0 || ^6.0.0",
         "tslib": "^2.6.3",
         "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
       }
@@ -1161,85 +1161,105 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.18.0.tgz",
-      "integrity": "sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.3.1.tgz",
+      "integrity": "sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
-        "prisma": "*"
+        "prisma": "*",
+        "typescript": ">=5.1.0"
       },
       "peerDependenciesMeta": {
         "prisma": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.18.0.tgz",
-      "integrity": "sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw=="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.3.1.tgz",
+      "integrity": "sha512-RrEBkd+HLZx+ydfmYT0jUj7wjLiS95wfTOSQ+8FQbvb6vHh5AeKfEPt/XUQ5+Buljj8hltEfOslEW57/wQIVeA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.18.0.tgz",
-      "integrity": "sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.3.1.tgz",
+      "integrity": "sha512-sXdqEVLyGAJ5/iUoG/Ea5AdHMN71m6PzMBWRQnLmhhOejzqAaEr8rUd623ql6OJpED4s/U4vIn4dg1qkF7vGag==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/fetch-engine": "6.3.1",
+        "@prisma/get-platform": "6.3.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg=="
+      "version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0.tgz",
+      "integrity": "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz",
-      "integrity": "sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.3.1.tgz",
+      "integrity": "sha512-HOf/0umOgt+/S2xtZze+FHKoxpVg4YpVxROr6g2YG09VsI3Ipyb+rGvD6QGbCqkq5NTWAAZoOGNL+oy7t+IhaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/get-platform": "6.3.1"
       }
     },
     "node_modules/@prisma/generator-helper": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.18.0.tgz",
-      "integrity": "sha512-3ffmrd9KE8ssg/fwyvfwMxrDAunLF8DLFjfwYnDRE7VaNIhkUVZwB77jAwpMCtukvCsAp14WGWu4itvLMzH3GQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-6.3.1.tgz",
+      "integrity": "sha512-hX2fxjMksyAWAS0OcDi7GVmRUqsZ35ZY3Zla1EfO+uDYW6BY+om8kuKHyKkIvvRcUlTmL+xccl+nJwNToqP/aA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.3.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.18.0.tgz",
-      "integrity": "sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.3.1.tgz",
+      "integrity": "sha512-AYLq6Hk9xG73JdLWJ3Ip9Wg/vlP7xPvftGBalsPzKDOHr/ImhwJ09eS8xC2vNT12DlzGxhfk8BkL0ve2OriNhQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.3.1"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-5.18.0.tgz",
-      "integrity": "sha512-NYG69q0FxpPHXDtEM2GS5kU22IwgtriCceNH00dWP9dV7oHz23+8QWJMlDsICTR7gnULLCeS2gWBuXWTS1PRmA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-6.3.1.tgz",
+      "integrity": "sha512-l/FvEEqlprGUXWoU1FpzgWOdclfyXkpGcfvxk3lWdjECt6B097umfsf4/bUploDWZzUN8EM42KnkXY2I0vv3CQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines": "5.18.0",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/generator-helper": "5.18.0",
-        "@prisma/get-platform": "5.18.0",
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/schema-files-loader": "5.18.0",
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines": "6.3.1",
+        "@prisma/fetch-engine": "6.3.1",
+        "@prisma/generator-helper": "6.3.1",
+        "@prisma/get-platform": "6.3.1",
+        "@prisma/prisma-schema-wasm": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/schema-files-loader": "6.3.1",
         "arg": "5.0.2",
         "prompts": "2.4.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@prisma/internals/node_modules/arg": {
@@ -1247,16 +1267,18 @@
       "license": "MIT"
     },
     "node_modules/@prisma/prisma-schema-wasm": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-2h7MDiYVXHVSdz0CylOUktVouPHRKUw5ciXz2r/oZsO2T6Zycez/eSvh4SKiKbHuxDq6SSb3R97mO7bjzh+NVQ=="
+      "version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0.tgz",
+      "integrity": "sha512-eUGf3d4K5XaQwfxr61Cbjq7ZpU+xrp5FVpt+NV+ZZQ9hxvKBL+tzi5gA4qufJ6BFC1WohgBSjelYbW+UUt3vXw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/schema-files-loader": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-5.18.0.tgz",
-      "integrity": "sha512-JtjPOZ8odMMr3etCcQ5kDsuljmckuNNCRMJglouPWSyzRbv4nOQJZCD4qPmoMUSoX0gwV7wGgwUw50XsoFYVzA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.3.1.tgz",
+      "integrity": "sha512-kdH6RL0Yy8a2Lqb96UJBp40Q8+Hei9qukEDlhg8an2E8uIPaerL72ME8f6EfI9zYu33ddc69MH2dES1DfYdY/A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
+        "@prisma/prisma-schema-wasm": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
         "fs-extra": "11.1.1"
       }
     },
@@ -2595,6 +2617,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
       "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3638,6 +3661,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4519,19 +4543,31 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.18.0.tgz",
-      "integrity": "sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.3.1.tgz",
+      "integrity": "sha512-JKCZWvBC3enxk51tY4TWzS4b5iRt4sSU1uHn2I183giZTvonXaQonzVtjLzpOHE7qu9MxY510kAtFGJwryKe3Q==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.18.0"
+        "@prisma/engines": "6.3.1"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prompts": {
@@ -5231,7 +5267,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5258,6 +5294,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -6378,71 +6415,71 @@
       }
     },
     "@prisma/client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.18.0.tgz",
-      "integrity": "sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.3.1.tgz",
+      "integrity": "sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA==",
       "dev": true,
       "requires": {}
     },
     "@prisma/debug": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.18.0.tgz",
-      "integrity": "sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw=="
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.3.1.tgz",
+      "integrity": "sha512-RrEBkd+HLZx+ydfmYT0jUj7wjLiS95wfTOSQ+8FQbvb6vHh5AeKfEPt/XUQ5+Buljj8hltEfOslEW57/wQIVeA=="
     },
     "@prisma/engines": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.18.0.tgz",
-      "integrity": "sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.3.1.tgz",
+      "integrity": "sha512-sXdqEVLyGAJ5/iUoG/Ea5AdHMN71m6PzMBWRQnLmhhOejzqAaEr8rUd623ql6OJpED4s/U4vIn4dg1qkF7vGag==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/fetch-engine": "6.3.1",
+        "@prisma/get-platform": "6.3.1"
       }
     },
     "@prisma/engines-version": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg=="
+      "version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0.tgz",
+      "integrity": "sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA=="
     },
     "@prisma/fetch-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz",
-      "integrity": "sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.3.1.tgz",
+      "integrity": "sha512-HOf/0umOgt+/S2xtZze+FHKoxpVg4YpVxROr6g2YG09VsI3Ipyb+rGvD6QGbCqkq5NTWAAZoOGNL+oy7t+IhaQ==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines-version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/get-platform": "6.3.1"
       }
     },
     "@prisma/generator-helper": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.18.0.tgz",
-      "integrity": "sha512-3ffmrd9KE8ssg/fwyvfwMxrDAunLF8DLFjfwYnDRE7VaNIhkUVZwB77jAwpMCtukvCsAp14WGWu4itvLMzH3GQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-6.3.1.tgz",
+      "integrity": "sha512-hX2fxjMksyAWAS0OcDi7GVmRUqsZ35ZY3Zla1EfO+uDYW6BY+om8kuKHyKkIvvRcUlTmL+xccl+nJwNToqP/aA==",
       "requires": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.3.1"
       }
     },
     "@prisma/get-platform": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.18.0.tgz",
-      "integrity": "sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.3.1.tgz",
+      "integrity": "sha512-AYLq6Hk9xG73JdLWJ3Ip9Wg/vlP7xPvftGBalsPzKDOHr/ImhwJ09eS8xC2vNT12DlzGxhfk8BkL0ve2OriNhQ==",
       "requires": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.3.1"
       }
     },
     "@prisma/internals": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-5.18.0.tgz",
-      "integrity": "sha512-NYG69q0FxpPHXDtEM2GS5kU22IwgtriCceNH00dWP9dV7oHz23+8QWJMlDsICTR7gnULLCeS2gWBuXWTS1PRmA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-6.3.1.tgz",
+      "integrity": "sha512-l/FvEEqlprGUXWoU1FpzgWOdclfyXkpGcfvxk3lWdjECt6B097umfsf4/bUploDWZzUN8EM42KnkXY2I0vv3CQ==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines": "5.18.0",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/generator-helper": "5.18.0",
-        "@prisma/get-platform": "5.18.0",
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/schema-files-loader": "5.18.0",
+        "@prisma/debug": "6.3.1",
+        "@prisma/engines": "6.3.1",
+        "@prisma/fetch-engine": "6.3.1",
+        "@prisma/generator-helper": "6.3.1",
+        "@prisma/get-platform": "6.3.1",
+        "@prisma/prisma-schema-wasm": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+        "@prisma/schema-files-loader": "6.3.1",
         "arg": "5.0.2",
         "prompts": "2.4.2"
       },
@@ -6453,16 +6490,16 @@
       }
     },
     "@prisma/prisma-schema-wasm": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-2h7MDiYVXHVSdz0CylOUktVouPHRKUw5ciXz2r/oZsO2T6Zycez/eSvh4SKiKbHuxDq6SSb3R97mO7bjzh+NVQ=="
+      "version": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0.tgz",
+      "integrity": "sha512-eUGf3d4K5XaQwfxr61Cbjq7ZpU+xrp5FVpt+NV+ZZQ9hxvKBL+tzi5gA4qufJ6BFC1WohgBSjelYbW+UUt3vXw=="
     },
     "@prisma/schema-files-loader": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-5.18.0.tgz",
-      "integrity": "sha512-JtjPOZ8odMMr3etCcQ5kDsuljmckuNNCRMJglouPWSyzRbv4nOQJZCD4qPmoMUSoX0gwV7wGgwUw50XsoFYVzA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.3.1.tgz",
+      "integrity": "sha512-kdH6RL0Yy8a2Lqb96UJBp40Q8+Hei9qukEDlhg8an2E8uIPaerL72ME8f6EfI9zYu33ddc69MH2dES1DfYdY/A==",
       "requires": {
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
+        "@prisma/prisma-schema-wasm": "6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0",
         "fs-extra": "11.1.1"
       }
     },
@@ -8770,12 +8807,13 @@
       }
     },
     "prisma": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.18.0.tgz",
-      "integrity": "sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.3.1.tgz",
+      "integrity": "sha512-JKCZWvBC3enxk51tY4TWzS4b5iRt4sSU1uHn2I183giZTvonXaQonzVtjLzpOHE7qu9MxY510kAtFGJwryKe3Q==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "5.18.0"
+        "@prisma/engines": "6.3.1",
+        "fsevents": "2.3.3"
       }
     },
     "prompts": {
@@ -9204,7 +9242,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true
+      "devOptional": true
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
     "typegraphql-prisma": "lib/generator.js"
   },
   "peerDependencies": {
-    "@prisma/client": "^5.18.0",
+    "@prisma/client": "^5.18.0 || ^6.0.0",
     "@types/graphql-fields": "^1.3.9",
     "@types/node": "*",
     "graphql-fields": "^2.0.3",
     "graphql-scalars": "^1.23.0",
-    "prisma": "^5.18.0",
+    "prisma": "^5.18.0 || ^6.0.0",
     "tslib": "^2.6.3",
     "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^5.18.0",
-    "@prisma/internals": "^5.18.0",
+    "@prisma/generator-helper": "^6.3.1",
+    "@prisma/internals": "^6.3.1",
     "pluralize": "^8.0.0",
     "semver": "^7.6.3",
     "ts-morph": "^23.0.0",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",
-    "@prisma/client": "^5.18.0",
+    "@prisma/client": "^6.3.1",
     "@types/graphql-fields": "^1.3.9",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.1.0",
@@ -57,7 +57,7 @@
     "pg": "^8.12.0",
     "prettier": "^3.3.3",
     "prettier-2": "npm:prettier@^2",
-    "prisma": "^5.18.0",
+    "prisma": "^6.3.1",
     "reflect-metadata": "0.1.13",
     "ts-jest": "~29.2.4",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "typegraphql-prisma": "lib/generator.js"
   },
   "peerDependencies": {
-    "@prisma/client": "^5.18.0 || ^6.0.0",
+    "@prisma/client": "^6.0.0",
     "@types/graphql-fields": "^1.3.9",
     "@types/node": "*",
     "graphql-fields": "^2.0.3",
     "graphql-scalars": "^1.23.0",
-    "prisma": "^5.18.0 || ^6.0.0",
+    "prisma": "^6.0.0",
     "tslib": "^2.6.3",
     "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
   },

--- a/src/generator/config.ts
+++ b/src/generator/config.ts
@@ -26,6 +26,7 @@ export const supportedMutationActions = [
   "updateOne",
   "deleteMany",
   "updateMany",
+  "updateManyAndReturn",
   "upsertOne",
 ] satisfies (keyof typeof DMMF.ModelAction)[];
 export type SupportedMutations = (typeof supportedMutationActions)[number];

--- a/src/generator/dmmf/transform.ts
+++ b/src/generator/dmmf/transform.ts
@@ -304,6 +304,18 @@ export function getMappedOutputTypeName(
     return `CreateManyAndReturn${modelTypeName}`;
   }
 
+  if (
+    outputTypeName.startsWith("UpdateMany") &&
+    outputTypeName.endsWith("AndReturnOutputType")
+  ) {
+    const modelTypeName = dmmfDocument.getModelTypeName(
+      outputTypeName
+        .replace("UpdateMany", "")
+        .replace("AndReturnOutputType", ""),
+    );
+    return `UpdateManyAndReturn${modelTypeName}`;
+  }
+
   if (dmmfDocument.isModelName(outputTypeName)) {
     return dmmfDocument.getModelTypeName(outputTypeName)!;
   }

--- a/src/generator/dmmf/types.ts
+++ b/src/generator/dmmf/types.ts
@@ -90,7 +90,7 @@ export namespace DMMF {
   }>;
   export type FieldDefault = ReadonlyDeep<{
     name: string;
-    args: any[];
+    args: (string | number)[];
   }>;
   export type FieldDefaultScalar = string | boolean | number;
   export type Schema = ReadonlyDeep<{
@@ -247,6 +247,7 @@ export namespace DMMF {
     createManyAndReturn = "createManyAndReturn",
     updateOne = "updateOne",
     updateMany = "updateMany",
+    updateManyAndReturn = "updateManyAndReturn",
     upsertOne = "upsertOne",
     deleteOne = "deleteOne",
     deleteMany = "deleteMany",

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -179,6 +179,7 @@ function getInputKeywordPhrasePosition(inputTypeName: string) {
     "Upsert",
     "ScalarWhere",
     "Where",
+    "ScalarRelationFilter",
     "ListRelationFilter",
     "RelationFilter",
     "Filter",

--- a/tests/functional/__snapshots__/integration.ts.snap
+++ b/tests/functional/__snapshots__/integration.ts.snap
@@ -100,12 +100,14 @@ type Mutation {
   createManyUser(data: [UserCreateManyInput!]!, skipDuplicates: Boolean): AffectedRowsOutput!
   createOnePost(data: PostCreateInput!): Post!
   createOneUser(data: UserCreateInput): User!
-  deleteManyPost(where: PostWhereInput): AffectedRowsOutput!
-  deleteManyUser(where: UserWhereInput): AffectedRowsOutput!
+  deleteManyPost(limit: Int, where: PostWhereInput): AffectedRowsOutput!
+  deleteManyUser(limit: Int, where: UserWhereInput): AffectedRowsOutput!
   deleteOnePost(where: PostWhereUniqueInput!): Post
   deleteOneUser(where: UserWhereUniqueInput!): User
-  updateManyPost(data: PostUpdateManyMutationInput!, where: PostWhereInput): AffectedRowsOutput!
-  updateManyUser(data: UserUpdateManyMutationInput!, where: UserWhereInput): AffectedRowsOutput!
+  updateManyAndReturnPost(data: PostUpdateManyMutationInput!, limit: Int, where: PostWhereInput): [UpdateManyAndReturnPost!]!
+  updateManyAndReturnUser(data: UserUpdateManyMutationInput!, limit: Int, where: UserWhereInput): [UpdateManyAndReturnUser!]!
+  updateManyPost(data: PostUpdateManyMutationInput!, limit: Int, where: PostWhereInput): AffectedRowsOutput!
+  updateManyUser(data: UserUpdateManyMutationInput!, limit: Int, where: UserWhereInput): AffectedRowsOutput!
   updateOnePost(data: PostUpdateInput!, where: PostWhereUniqueInput!): Post
   updateOneUser(data: UserUpdateInput!, where: UserWhereUniqueInput!): User
   upsertOnePost(create: PostCreateInput!, update: PostUpdateInput!, where: PostWhereUniqueInput!): Post!
@@ -481,7 +483,7 @@ input PostWhereInput {
   AND: [PostWhereInput!]
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
-  author: UserRelationFilter
+  author: UserScalarRelationFilter
   authorId: IntFilter
   color: EnumColorFilter
   content: StringFilter
@@ -492,7 +494,7 @@ input PostWhereUniqueInput {
   AND: [PostWhereInput!]
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
-  author: UserRelationFilter
+  author: UserScalarRelationFilter
   authorId: IntFilter
   color: EnumColorFilter
   content: StringFilter
@@ -601,6 +603,19 @@ input StringWithAggregatesFilter {
   startsWith: String
 }
 
+type UpdateManyAndReturnPost {
+  author: User!
+  authorId: Int!
+  color: Color!
+  content: String!
+  uuid: String!
+}
+
+type UpdateManyAndReturnUser {
+  id: Int!
+  name: String
+}
+
 type User {
   _count: UserCount
   id: Int!
@@ -702,14 +717,14 @@ input UserOrderByWithRelationInput {
   posts: PostOrderByRelationAggregateInput
 }
 
-input UserRelationFilter {
-  is: UserWhereInput
-  isNot: UserWhereInput
-}
-
 enum UserScalarFieldEnum {
   id
   name
+}
+
+input UserScalarRelationFilter {
+  is: UserWhereInput
+  isNot: UserWhereInput
 }
 
 input UserScalarWhereWithAggregatesInput {
@@ -814,6 +829,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -830,6 +846,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -847,6 +864,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -864,6 +882,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -934,7 +953,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -958,6 +977,8 @@ exports[`generator integration should generates TypeGraphQL classes files to out
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts

--- a/tests/regression/__snapshots__/crud.ts.snap
+++ b/tests/regression/__snapshots__/crud.ts.snap
@@ -350,6 +350,7 @@ export { FindUniqueUserResolver } from \\"./User/FindUniqueUserResolver\\";
 export { FindUniqueUserOrThrowResolver } from \\"./User/FindUniqueUserOrThrowResolver\\";
 export { GroupByUserResolver } from \\"./User/GroupByUserResolver\\";
 export { UpdateManyUserResolver } from \\"./User/UpdateManyUserResolver\\";
+export { UpdateManyAndReturnUserResolver } from \\"./User/UpdateManyAndReturnUserResolver\\";
 export { UpdateOneUserResolver } from \\"./User/UpdateOneUserResolver\\";
 export { UpsertOneUserResolver } from \\"./User/UpsertOneUserResolver\\";
 "
@@ -468,6 +469,11 @@ export class DeleteManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -702,6 +708,7 @@ export { FindManyUserArgs } from \\"./FindManyUserArgs\\";
 export { FindUniqueUserArgs } from \\"./FindUniqueUserArgs\\";
 export { FindUniqueUserOrThrowArgs } from \\"./FindUniqueUserOrThrowArgs\\";
 export { GroupByUserArgs } from \\"./GroupByUserArgs\\";
+export { UpdateManyAndReturnUserArgs } from \\"./UpdateManyAndReturnUserArgs\\";
 export { UpdateManyUserArgs } from \\"./UpdateManyUserArgs\\";
 export { UpdateOneUserArgs } from \\"./UpdateOneUserArgs\\";
 export { UpsertOneUserArgs } from \\"./UpsertOneUserArgs\\";
@@ -725,6 +732,11 @@ export class UpdateManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -956,6 +968,7 @@ export { FindManyFirstModelArgs } from \\"./FindManyFirstModelArgs\\";
 export { FindUniqueFirstModelArgs } from \\"./FindUniqueFirstModelArgs\\";
 export { FindUniqueFirstModelOrThrowArgs } from \\"./FindUniqueFirstModelOrThrowArgs\\";
 export { GroupByFirstModelArgs } from \\"./GroupByFirstModelArgs\\";
+export { UpdateManyAndReturnFirstModelArgs } from \\"./UpdateManyAndReturnFirstModelArgs\\";
 export { UpdateManyFirstModelArgs } from \\"./UpdateManyFirstModelArgs\\";
 export { UpdateOneFirstModelArgs } from \\"./UpdateOneFirstModelArgs\\";
 export { UpsertOneFirstModelArgs } from \\"./UpsertOneFirstModelArgs\\";
@@ -1098,6 +1111,7 @@ export { FindManySecondModelArgs } from \\"./FindManySecondModelArgs\\";
 export { FindUniqueSecondModelArgs } from \\"./FindUniqueSecondModelArgs\\";
 export { FindUniqueSecondModelOrThrowArgs } from \\"./FindUniqueSecondModelOrThrowArgs\\";
 export { GroupBySecondModelArgs } from \\"./GroupBySecondModelArgs\\";
+export { UpdateManyAndReturnSecondModelArgs } from \\"./UpdateManyAndReturnSecondModelArgs\\";
 export { UpdateManySecondModelArgs } from \\"./UpdateManySecondModelArgs\\";
 export { UpdateOneSecondModelArgs } from \\"./UpdateOneSecondModelArgs\\";
 export { UpsertOneSecondModelArgs } from \\"./UpsertOneSecondModelArgs\\";
@@ -1126,6 +1140,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -1134,6 +1149,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -1282,6 +1298,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -1321,6 +1348,7 @@ export { FindUniqueUserResolver } from \\"./User/FindUniqueUserResolver\\";
 export { FindUniqueUserOrThrowResolver } from \\"./User/FindUniqueUserOrThrowResolver\\";
 export { GroupByUserResolver } from \\"./User/GroupByUserResolver\\";
 export { UpdateManyUserResolver } from \\"./User/UpdateManyUserResolver\\";
+export { UpdateManyAndReturnUserResolver } from \\"./User/UpdateManyAndReturnUserResolver\\";
 export { UpdateOneUserResolver } from \\"./User/UpdateOneUserResolver\\";
 export { UpsertOneUserResolver } from \\"./User/UpsertOneUserResolver\\";
 "
@@ -1373,6 +1401,7 @@ import { FindManyStaffArgs } from \\"./args/FindManyStaffArgs\\";
 import { FindUniqueStaffArgs } from \\"./args/FindUniqueStaffArgs\\";
 import { FindUniqueStaffOrThrowArgs } from \\"./args/FindUniqueStaffOrThrowArgs\\";
 import { GroupByStaffArgs } from \\"./args/GroupByStaffArgs\\";
+import { UpdateManyAndReturnStaffArgs } from \\"./args/UpdateManyAndReturnStaffArgs\\";
 import { UpdateManyStaffArgs } from \\"./args/UpdateManyStaffArgs\\";
 import { UpdateOneStaffArgs } from \\"./args/UpdateOneStaffArgs\\";
 import { UpsertOneStaffArgs } from \\"./args/UpsertOneStaffArgs\\";
@@ -1382,6 +1411,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateStaff } from \\"../../outputs/AggregateStaff\\";
 import { CreateManyAndReturnStaff } from \\"../../outputs/CreateManyAndReturnStaff\\";
 import { StaffGroupBy } from \\"../../outputs/StaffGroupBy\\";
+import { UpdateManyAndReturnStaff } from \\"../../outputs/UpdateManyAndReturnStaff\\";
 
 @TypeGraphQL.Resolver(_of => Staff)
 export class StaffCrudResolver {
@@ -1529,6 +1559,17 @@ export class StaffCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnStaff], {
+    nullable: false
+  })
+  async updateManyAndReturnStaff(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnStaffArgs): Promise<UpdateManyAndReturnStaff[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).staff.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Staff, {
     nullable: true
   })
@@ -1569,6 +1610,7 @@ import { FindManyStaffArgs } from \\"./args/FindManyStaffArgs\\";
 import { FindUniqueStaffArgs } from \\"./args/FindUniqueStaffArgs\\";
 import { FindUniqueStaffOrThrowArgs } from \\"./args/FindUniqueStaffOrThrowArgs\\";
 import { GroupByStaffArgs } from \\"./args/GroupByStaffArgs\\";
+import { UpdateManyAndReturnStaffArgs } from \\"./args/UpdateManyAndReturnStaffArgs\\";
 import { UpdateManyStaffArgs } from \\"./args/UpdateManyStaffArgs\\";
 import { UpdateOneStaffArgs } from \\"./args/UpdateOneStaffArgs\\";
 import { UpsertOneStaffArgs } from \\"./args/UpsertOneStaffArgs\\";
@@ -1578,6 +1620,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateStaff } from \\"../../outputs/AggregateStaff\\";
 import { CreateManyAndReturnStaff } from \\"../../outputs/CreateManyAndReturnStaff\\";
 import { StaffGroupBy } from \\"../../outputs/StaffGroupBy\\";
+import { UpdateManyAndReturnStaff } from \\"../../outputs/UpdateManyAndReturnStaff\\";
 
 @TypeGraphQL.Resolver(_of => Staff)
 export class StaffCrudResolver {
@@ -1725,6 +1768,17 @@ export class StaffCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnStaff], {
+    nullable: false
+  })
+  async updateManyAndReturnStaff(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnStaffArgs): Promise<UpdateManyAndReturnStaff[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).staff.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Staff, {
     nullable: true
   })
@@ -1811,6 +1865,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -1819,6 +1874,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -1967,6 +2023,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -2007,6 +2074,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2015,6 +2083,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2163,6 +2232,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args(_type => UpdateManyAndReturnUserArgs) args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -2206,6 +2286,7 @@ const FindManyUserArgs_1 = require(\\"./args/FindManyUserArgs\\");
 const FindUniqueUserArgs_1 = require(\\"./args/FindUniqueUserArgs\\");
 const FindUniqueUserOrThrowArgs_1 = require(\\"./args/FindUniqueUserOrThrowArgs\\");
 const GroupByUserArgs_1 = require(\\"./args/GroupByUserArgs\\");
+const UpdateManyAndReturnUserArgs_1 = require(\\"./args/UpdateManyAndReturnUserArgs\\");
 const UpdateManyUserArgs_1 = require(\\"./args/UpdateManyUserArgs\\");
 const UpdateOneUserArgs_1 = require(\\"./args/UpdateOneUserArgs\\");
 const UpsertOneUserArgs_1 = require(\\"./args/UpsertOneUserArgs\\");
@@ -2214,6 +2295,7 @@ const User_1 = require(\\"../../../models/User\\");
 const AffectedRowsOutput_1 = require(\\"../../outputs/AffectedRowsOutput\\");
 const AggregateUser_1 = require(\\"../../outputs/AggregateUser\\");
 const CreateManyAndReturnUser_1 = require(\\"../../outputs/CreateManyAndReturnUser\\");
+const UpdateManyAndReturnUser_1 = require(\\"../../outputs/UpdateManyAndReturnUser\\");
 const UserGroupBy_1 = require(\\"../../outputs/UserGroupBy\\");
 let UserCrudResolver = class UserCrudResolver {
     async aggregateUser(ctx, info, args) {
@@ -2302,6 +2384,13 @@ let UserCrudResolver = class UserCrudResolver {
     async updateManyUser(ctx, info, args) {
         const { _count } = (0, helpers_1.transformInfoIntoPrismaArgs)(info);
         return (0, helpers_1.getPrismaFromContext)(ctx).user.updateMany({
+            ...args,
+            ...(_count && (0, helpers_1.transformCountFieldIntoSelectRelationsCount)(_count)),
+        });
+    }
+    async updateManyAndReturnUser(ctx, info, args) {
+        const { _count } = (0, helpers_1.transformInfoIntoPrismaArgs)(info);
+        return (0, helpers_1.getPrismaFromContext)(ctx).user.updateManyAndReturn({
             ...args,
             ...(_count && (0, helpers_1.transformCountFieldIntoSelectRelationsCount)(_count)),
         });
@@ -2466,6 +2555,17 @@ tslib_1.__decorate([
     tslib_1.__metadata(\\"design:returntype\\", Promise)
 ], UserCrudResolver.prototype, \\"updateManyUser\\", null);
 tslib_1.__decorate([
+    TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser_1.UpdateManyAndReturnUser], {
+        nullable: false
+    }),
+    tslib_1.__param(0, TypeGraphQL.Ctx()),
+    tslib_1.__param(1, TypeGraphQL.Info()),
+    tslib_1.__param(2, TypeGraphQL.Args()),
+    tslib_1.__metadata(\\"design:type\\", Function),
+    tslib_1.__metadata(\\"design:paramtypes\\", [Object, Object, UpdateManyAndReturnUserArgs_1.UpdateManyAndReturnUserArgs]),
+    tslib_1.__metadata(\\"design:returntype\\", Promise)
+], UserCrudResolver.prototype, \\"updateManyAndReturnUser\\", null);
+tslib_1.__decorate([
     TypeGraphQL.Mutation(_returns => User_1.User, {
         nullable: true
     }),
@@ -2508,6 +2608,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2520,6 +2621,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2723,6 +2825,21 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false,
+  })
+  async updateManyAndReturnUser(
+    @TypeGraphQL.Ctx() ctx: any,
+    @TypeGraphQL.Info() info: GraphQLResolveInfo,
+    @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs,
+  ): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true,
   })
@@ -2771,6 +2888,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2779,6 +2897,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2922,6 +3041,17 @@ export class UserCrudResolver {
     async updateManyUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyUserArgs): Promise<AffectedRowsOutput> {
          const { _count } = transformInfoIntoPrismaArgs(info);
                     return getPrismaFromContext(ctx).user.updateMany({
+                      ...args,
+                      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+                    });
+    }
+
+    @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+            nullable: false
+        })
+    async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+         const { _count } = transformInfoIntoPrismaArgs(info);
+                    return getPrismaFromContext(ctx).user.updateManyAndReturn({
                       ...args,
                       ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
                     });
@@ -3376,6 +3506,11 @@ export class DeleteManyClientArgs {
     nullable: true
   })
   where?: ClientWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -3537,6 +3672,7 @@ export { FindManyClientArgs } from \\"./FindManyClientArgs\\";
 export { FindUniqueClientArgs } from \\"./FindUniqueClientArgs\\";
 export { FindUniqueClientOrThrowArgs } from \\"./FindUniqueClientOrThrowArgs\\";
 export { GroupByClientArgs } from \\"./GroupByClientArgs\\";
+export { UpdateManyAndReturnClientArgs } from \\"./UpdateManyAndReturnClientArgs\\";
 export { UpdateManyClientArgs } from \\"./UpdateManyClientArgs\\";
 export { UpdateOneClientArgs } from \\"./UpdateOneClientArgs\\";
 export { UpsertOneClientArgs } from \\"./UpsertOneClientArgs\\";
@@ -3581,6 +3717,11 @@ export class UpdateManyClientArgs {
     nullable: true
   })
   where?: ClientWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -3650,6 +3791,7 @@ import { FindManyClientArgs } from \\"./args/FindManyClientArgs\\";
 import { FindUniqueClientArgs } from \\"./args/FindUniqueClientArgs\\";
 import { FindUniqueClientOrThrowArgs } from \\"./args/FindUniqueClientOrThrowArgs\\";
 import { GroupByClientArgs } from \\"./args/GroupByClientArgs\\";
+import { UpdateManyAndReturnClientArgs } from \\"./args/UpdateManyAndReturnClientArgs\\";
 import { UpdateManyClientArgs } from \\"./args/UpdateManyClientArgs\\";
 import { UpdateOneClientArgs } from \\"./args/UpdateOneClientArgs\\";
 import { UpsertOneClientArgs } from \\"./args/UpsertOneClientArgs\\";
@@ -3659,6 +3801,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateClient } from \\"../../outputs/AggregateClient\\";
 import { ClientGroupBy } from \\"../../outputs/ClientGroupBy\\";
 import { CreateManyAndReturnClient } from \\"../../outputs/CreateManyAndReturnClient\\";
+import { UpdateManyAndReturnClient } from \\"../../outputs/UpdateManyAndReturnClient\\";
 
 @TypeGraphQL.Resolver(_of => Client)
 export class ClientCrudResolver {
@@ -3806,6 +3949,17 @@ export class ClientCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnClient], {
+    nullable: false
+  })
+  async updateManyAndReturnClient(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnClientArgs): Promise<UpdateManyAndReturnClient[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Client, {
     nullable: true
   })
@@ -3872,6 +4026,7 @@ import { FindManyMainUserArgs } from \\"./args/FindManyMainUserArgs\\";
 import { FindUniqueMainUserArgs } from \\"./args/FindUniqueMainUserArgs\\";
 import { FindUniqueMainUserOrThrowArgs } from \\"./args/FindUniqueMainUserOrThrowArgs\\";
 import { GroupByMainUserArgs } from \\"./args/GroupByMainUserArgs\\";
+import { UpdateManyAndReturnMainUserArgs } from \\"./args/UpdateManyAndReturnMainUserArgs\\";
 import { UpdateManyMainUserArgs } from \\"./args/UpdateManyMainUserArgs\\";
 import { UpdateOneMainUserArgs } from \\"./args/UpdateOneMainUserArgs\\";
 import { UpsertOneMainUserArgs } from \\"./args/UpsertOneMainUserArgs\\";
@@ -3881,6 +4036,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateMainUser } from \\"../../outputs/AggregateMainUser\\";
 import { CreateManyAndReturnMainUser } from \\"../../outputs/CreateManyAndReturnMainUser\\";
 import { MainUserGroupBy } from \\"../../outputs/MainUserGroupBy\\";
+import { UpdateManyAndReturnMainUser } from \\"../../outputs/UpdateManyAndReturnMainUser\\";
 
 @TypeGraphQL.Resolver(_of => MainUser)
 export class MainUserCrudResolver {
@@ -4028,6 +4184,17 @@ export class MainUserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnMainUser], {
+    nullable: false
+  })
+  async updateManyAndReturnMainUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnMainUserArgs): Promise<UpdateManyAndReturnMainUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => MainUser, {
     nullable: true
   })
@@ -4085,6 +4252,11 @@ export class UpdateManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;

--- a/tests/regression/__snapshots__/emit-only.ts.snap
+++ b/tests/regression/__snapshots__/emit-only.ts.snap
@@ -31,6 +31,7 @@ const actionResolversMap = {
     getUser: actionResolvers.FindUniqueUserOrThrowResolver,
     groupByUser: actionResolvers.GroupByUserResolver,
     updateManyUser: actionResolvers.UpdateManyUserResolver,
+    updateManyAndReturnUser: actionResolvers.UpdateManyAndReturnUserResolver,
     updateOneUser: actionResolvers.UpdateOneUserResolver,
     upsertOneUser: actionResolvers.UpsertOneUserResolver
   },
@@ -48,20 +49,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateManyAndReturnUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneUserArgs: [\\"data\\"],
-  DeleteManyUserArgs: [\\"where\\"],
+  DeleteManyUserArgs: [\\"where\\", \\"limit\\"],
   DeleteOneUserArgs: [\\"where\\"],
   FindFirstUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstUserOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -69,14 +71,15 @@ const argsInfo = {
   FindUniqueUserArgs: [\\"where\\"],
   FindUniqueUserOrThrowArgs: [\\"where\\"],
   GroupByUserArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyUserArgs: [\\"data\\", \\"where\\"],
+  UpdateManyUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneUserArgs: [\\"data\\", \\"where\\"],
   UpsertOneUserArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -84,7 +87,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -112,7 +116,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -281,7 +285,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -354,8 +360,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -365,7 +371,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -387,7 +393,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -502,6 +508,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -518,6 +525,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -535,6 +543,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -552,6 +561,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -630,7 +640,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -654,6 +664,8 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -700,6 +712,7 @@ const actionResolversMap = {
     getUser: actionResolvers.FindUniqueUserOrThrowResolver,
     groupByUser: actionResolvers.GroupByUserResolver,
     updateManyUser: actionResolvers.UpdateManyUserResolver,
+    updateManyAndReturnUser: actionResolvers.UpdateManyAndReturnUserResolver,
     updateOneUser: actionResolvers.UpdateOneUserResolver,
     upsertOneUser: actionResolvers.UpsertOneUserResolver
   },
@@ -717,20 +730,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateManyAndReturnUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneUserArgs: [\\"data\\"],
-  DeleteManyUserArgs: [\\"where\\"],
+  DeleteManyUserArgs: [\\"where\\", \\"limit\\"],
   DeleteOneUserArgs: [\\"where\\"],
   FindFirstUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstUserOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -738,14 +752,15 @@ const argsInfo = {
   FindUniqueUserArgs: [\\"where\\"],
   FindUniqueUserOrThrowArgs: [\\"where\\"],
   GroupByUserArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyUserArgs: [\\"data\\", \\"where\\"],
+  UpdateManyUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneUserArgs: [\\"data\\", \\"where\\"],
   UpsertOneUserArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -753,7 +768,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -781,7 +797,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -950,7 +966,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -1023,8 +1041,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -1034,7 +1052,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -1056,7 +1074,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -1171,6 +1189,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -1187,6 +1206,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -1204,6 +1224,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -1221,6 +1242,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -1299,7 +1321,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -1323,6 +1345,8 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -1451,8 +1475,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -1462,7 +1486,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -1484,7 +1508,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -1638,7 +1662,7 @@ exports[`emitOnly generator option when only 'inputs' is set should generate pro
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -1863,7 +1887,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -1945,6 +1971,8 @@ exports[`emitOnly generator option when only 'outputs' is set should generate pr
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -2129,8 +2157,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -2140,7 +2168,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -2162,7 +2190,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -2331,7 +2359,7 @@ exports[`emitOnly generator option when only 'relationResolvers' is set should g
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts

--- a/tests/regression/__snapshots__/enhance.ts.snap
+++ b/tests/regression/__snapshots__/enhance.ts.snap
@@ -32,6 +32,7 @@ const actionResolversMap = {
     getClient: actionResolvers.FindUniqueClientOrThrowResolver,
     groupByClient: actionResolvers.GroupByClientResolver,
     updateManyClient: actionResolvers.UpdateManyClientResolver,
+    updateManyAndReturnClient: actionResolvers.UpdateManyAndReturnClientResolver,
     updateOneClient: actionResolvers.UpdateOneClientResolver,
     upsertOneClient: actionResolvers.UpsertOneClientResolver
   },
@@ -49,20 +50,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  Client: [\\"aggregateClient\\", \\"createManyClient\\", \\"createManyAndReturnClient\\", \\"createOneClient\\", \\"deleteManyClient\\", \\"deleteOneClient\\", \\"findFirstClient\\", \\"findFirstClientOrThrow\\", \\"clients\\", \\"client\\", \\"getClient\\", \\"groupByClient\\", \\"updateManyClient\\", \\"updateOneClient\\", \\"upsertOneClient\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  Client: [\\"aggregateClient\\", \\"createManyClient\\", \\"createManyAndReturnClient\\", \\"createOneClient\\", \\"deleteManyClient\\", \\"deleteOneClient\\", \\"findFirstClient\\", \\"findFirstClientOrThrow\\", \\"clients\\", \\"client\\", \\"getClient\\", \\"groupByClient\\", \\"updateManyClient\\", \\"updateManyAndReturnClient\\", \\"updateOneClient\\", \\"upsertOneClient\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateClientArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyClientArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnClientArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneClientArgs: [\\"data\\"],
-  DeleteManyClientArgs: [\\"where\\"],
+  DeleteManyClientArgs: [\\"where\\", \\"limit\\"],
   DeleteOneClientArgs: [\\"where\\"],
   FindFirstClientArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstClientOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -70,14 +72,15 @@ const argsInfo = {
   FindUniqueClientArgs: [\\"where\\"],
   FindUniqueClientOrThrowArgs: [\\"where\\"],
   GroupByClientArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyClientArgs: [\\"data\\", \\"where\\"],
+  UpdateManyClientArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnClientArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneClientArgs: [\\"data\\", \\"where\\"],
   UpsertOneClientArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -85,7 +88,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -113,7 +117,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -329,7 +333,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnClient: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnClient: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -402,8 +408,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  ClientRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  ClientScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -413,7 +419,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -435,7 +441,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -549,19 +555,20 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -569,7 +576,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -597,7 +605,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -754,7 +762,8 @@ const outputsInfo = {
   PostCountAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\", \\"_all\\"],
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"]
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -808,7 +817,7 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostMaxOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
@@ -817,7 +826,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   DateTimeFieldUpdateOperationsInput: [\\"set\\"],
   BoolFieldUpdateOperationsInput: [\\"set\\"],
@@ -832,7 +841,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"]
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"]
 };
 
 type InputTypesNames = keyof typeof inputTypes;

--- a/tests/regression/__snapshots__/inputs.ts.snap
+++ b/tests/regression/__snapshots__/inputs.ts.snap
@@ -371,17 +371,17 @@ export class JsonWithAggregatesFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1101,17 +1101,17 @@ export class JsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1179,17 +1179,17 @@ export class JsonWithAggregatesFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1270,17 +1270,17 @@ export class NestedJsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1840,8 +1840,8 @@ import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 
-@TypeGraphQL.InputType(\\"FirstModelRelationFilter\\", {})
-export class FirstModelRelationFilter {
+@TypeGraphQL.InputType(\\"FirstModelScalarRelationFilter\\", {})
+export class FirstModelScalarRelationFilter {
   @TypeGraphQL.Field(_type => FirstModelWhereInput, {
     nullable: true
   })
@@ -2073,7 +2073,7 @@ exports[`inputs should properly generate input type classes for filtering models
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
-import { FirstModelRelationFilter } from \\"../inputs/FirstModelRelationFilter\\";
+import { FirstModelScalarRelationFilter } from \\"../inputs/FirstModelScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -2115,10 +2115,10 @@ export class SecondModelWhereInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => FirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => FirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: FirstModelRelationFilter | undefined;
+  firstModelField?: FirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -2128,7 +2128,7 @@ exports[`inputs should properly generate input type classes for filtering models
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
-import { FirstModelRelationFilter } from \\"../inputs/FirstModelRelationFilter\\";
+import { FirstModelScalarRelationFilter } from \\"../inputs/FirstModelScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { SecondModelWhereInput } from \\"../inputs/SecondModelWhereInput\\";
@@ -2170,10 +2170,10 @@ export class SecondModelWhereUniqueInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => FirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => FirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: FirstModelRelationFilter | undefined;
+  firstModelField?: FirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -2190,7 +2190,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -2496,17 +2496,17 @@ export class JsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -2746,17 +2746,17 @@ export class NestedJsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -3232,7 +3232,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -3460,7 +3460,7 @@ export { DirectorMaxOrderByAggregateInput } from \\"./DirectorMaxOrderByAggregat
 export { DirectorMinOrderByAggregateInput } from \\"./DirectorMinOrderByAggregateInput\\";
 export { DirectorOrderByWithAggregationInput } from \\"./DirectorOrderByWithAggregationInput\\";
 export { DirectorOrderByWithRelationInput } from \\"./DirectorOrderByWithRelationInput\\";
-export { DirectorRelationFilter } from \\"./DirectorRelationFilter\\";
+export { DirectorScalarRelationFilter } from \\"./DirectorScalarRelationFilter\\";
 export { DirectorScalarWhereWithAggregatesInput } from \\"./DirectorScalarWhereWithAggregatesInput\\";
 export { DirectorSumOrderByAggregateInput } from \\"./DirectorSumOrderByAggregateInput\\";
 export { DirectorUpdateInput } from \\"./DirectorUpdateInput\\";
@@ -3634,7 +3634,7 @@ exports[`inputs should properly generate input type classes for model with id ke
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
-import { DirectorRelationFilter } from \\"../inputs/DirectorRelationFilter\\";
+import { DirectorScalarRelationFilter } from \\"../inputs/DirectorScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
@@ -3675,10 +3675,10 @@ export class MovieWhereInput {
   })
   rating?: FloatFilter | undefined;
 
-  @TypeGraphQL.Field(_type => DirectorRelationFilter, {
+  @TypeGraphQL.Field(_type => DirectorScalarRelationFilter, {
     nullable: true
   })
-  director?: DirectorRelationFilter | undefined;
+  director?: DirectorScalarRelationFilter | undefined;
 }
 "
 `;
@@ -3688,7 +3688,7 @@ exports[`inputs should properly generate input type classes for model with id ke
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
-import { DirectorRelationFilter } from \\"../inputs/DirectorRelationFilter\\";
+import { DirectorScalarRelationFilter } from \\"../inputs/DirectorScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput } from \\"../inputs/MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput\\";
 import { MovieWhereInput } from \\"../inputs/MovieWhereInput\\";
@@ -3736,10 +3736,10 @@ export class MovieWhereUniqueInput {
   })
   rating?: FloatFilter | undefined;
 
-  @TypeGraphQL.Field(_type => DirectorRelationFilter, {
+  @TypeGraphQL.Field(_type => DirectorScalarRelationFilter, {
     nullable: true
   })
-  director?: DirectorRelationFilter | undefined;
+  director?: DirectorScalarRelationFilter | undefined;
 }
 "
 `;
@@ -3757,7 +3757,7 @@ export { DirectorMaxOrderByAggregateInput } from \\"./DirectorMaxOrderByAggregat
 export { DirectorMinOrderByAggregateInput } from \\"./DirectorMinOrderByAggregateInput\\";
 export { DirectorOrderByWithAggregationInput } from \\"./DirectorOrderByWithAggregationInput\\";
 export { DirectorOrderByWithRelationInput } from \\"./DirectorOrderByWithRelationInput\\";
-export { DirectorRelationFilter } from \\"./DirectorRelationFilter\\";
+export { DirectorScalarRelationFilter } from \\"./DirectorScalarRelationFilter\\";
 export { DirectorScalarWhereWithAggregatesInput } from \\"./DirectorScalarWhereWithAggregatesInput\\";
 export { DirectorSumOrderByAggregateInput } from \\"./DirectorSumOrderByAggregateInput\\";
 export { DirectorUpdateInput } from \\"./DirectorUpdateInput\\";
@@ -4573,7 +4573,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -5910,7 +5910,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -5981,7 +5981,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -6996,7 +6996,7 @@ export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggr
 export { FirstModelOrderByRelevanceInput } from \\"./FirstModelOrderByRelevanceInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -7443,8 +7443,8 @@ import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
 import { RenamedFirstModelWhereInput } from \\"../inputs/RenamedFirstModelWhereInput\\";
 
-@TypeGraphQL.InputType(\\"RenamedFirstModelRelationFilter\\", {})
-export class RenamedFirstModelRelationFilter {
+@TypeGraphQL.InputType(\\"RenamedFirstModelScalarRelationFilter\\", {})
+export class RenamedFirstModelScalarRelationFilter {
   @TypeGraphQL.Field(_type => RenamedFirstModelWhereInput, {
     nullable: true
   })
@@ -7678,7 +7678,7 @@ import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { RenamedFirstModelRelationFilter } from \\"../inputs/RenamedFirstModelRelationFilter\\";
+import { RenamedFirstModelScalarRelationFilter } from \\"../inputs/RenamedFirstModelScalarRelationFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
 @TypeGraphQL.InputType(\\"RenamedSecondModelWhereInput\\", {})
@@ -7718,10 +7718,10 @@ export class RenamedSecondModelWhereInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => RenamedFirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => RenamedFirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: RenamedFirstModelRelationFilter | undefined;
+  firstModelField?: RenamedFirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7733,7 +7733,7 @@ import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
 import { DecimalJSScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { RenamedFirstModelRelationFilter } from \\"../inputs/RenamedFirstModelRelationFilter\\";
+import { RenamedFirstModelScalarRelationFilter } from \\"../inputs/RenamedFirstModelScalarRelationFilter\\";
 import { RenamedSecondModelWhereInput } from \\"../inputs/RenamedSecondModelWhereInput\\";
 
 @TypeGraphQL.InputType(\\"RenamedSecondModelWhereUniqueInput\\", {})
@@ -7773,10 +7773,10 @@ export class RenamedSecondModelWhereUniqueInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => RenamedFirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => RenamedFirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: RenamedFirstModelRelationFilter | undefined;
+  firstModelField?: RenamedFirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7805,7 +7805,7 @@ export { RenamedFirstModelMaxOrderByAggregateInput } from \\"./RenamedFirstModel
 export { RenamedFirstModelMinOrderByAggregateInput } from \\"./RenamedFirstModelMinOrderByAggregateInput\\";
 export { RenamedFirstModelOrderByWithAggregationInput } from \\"./RenamedFirstModelOrderByWithAggregationInput\\";
 export { RenamedFirstModelOrderByWithRelationInput } from \\"./RenamedFirstModelOrderByWithRelationInput\\";
-export { RenamedFirstModelRelationFilter } from \\"./RenamedFirstModelRelationFilter\\";
+export { RenamedFirstModelScalarRelationFilter } from \\"./RenamedFirstModelScalarRelationFilter\\";
 export { RenamedFirstModelScalarWhereWithAggregatesInput } from \\"./RenamedFirstModelScalarWhereWithAggregatesInput\\";
 export { RenamedFirstModelSumOrderByAggregateInput } from \\"./RenamedFirstModelSumOrderByAggregateInput\\";
 export { RenamedFirstModelUpdateInput } from \\"./RenamedFirstModelUpdateInput\\";
@@ -7906,7 +7906,7 @@ import { BoolFilter } from \\"../inputs/BoolFilter\\";
 import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { OtherModelRelationFilter } from \\"../inputs/OtherModelRelationFilter\\";
+import { OtherModelScalarRelationFilter } from \\"../inputs/OtherModelScalarRelationFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
 @TypeGraphQL.InputType(\\"ExampleWhereInput\\", {})
@@ -7956,10 +7956,10 @@ export class ExampleWhereInput {
   })
   otherId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => OtherModelRelationFilter, {
+  @TypeGraphQL.Field(_type => OtherModelScalarRelationFilter, {
     nullable: true
   })
-  other?: OtherModelRelationFilter | undefined;
+  other?: OtherModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7974,7 +7974,7 @@ import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { ExampleWhereInput } from \\"../inputs/ExampleWhereInput\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { OtherModelRelationFilter } from \\"../inputs/OtherModelRelationFilter\\";
+import { OtherModelScalarRelationFilter } from \\"../inputs/OtherModelScalarRelationFilter\\";
 
 @TypeGraphQL.InputType(\\"ExampleWhereUniqueInput\\", {})
 export class ExampleWhereUniqueInput {
@@ -8023,10 +8023,10 @@ export class ExampleWhereUniqueInput {
   })
   otherId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => OtherModelRelationFilter, {
+  @TypeGraphQL.Field(_type => OtherModelScalarRelationFilter, {
     nullable: true
   })
-  other?: OtherModelRelationFilter | undefined;
+  other?: OtherModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -8092,7 +8092,7 @@ export { OtherModelMaxOrderByAggregateInput } from \\"./OtherModelMaxOrderByAggr
 export { OtherModelMinOrderByAggregateInput } from \\"./OtherModelMinOrderByAggregateInput\\";
 export { OtherModelOrderByWithAggregationInput } from \\"./OtherModelOrderByWithAggregationInput\\";
 export { OtherModelOrderByWithRelationInput } from \\"./OtherModelOrderByWithRelationInput\\";
-export { OtherModelRelationFilter } from \\"./OtherModelRelationFilter\\";
+export { OtherModelScalarRelationFilter } from \\"./OtherModelScalarRelationFilter\\";
 export { OtherModelScalarWhereWithAggregatesInput } from \\"./OtherModelScalarWhereWithAggregatesInput\\";
 export { OtherModelSumOrderByAggregateInput } from \\"./OtherModelSumOrderByAggregateInput\\";
 export { OtherModelUpdateInput } from \\"./OtherModelUpdateInput\\";
@@ -8780,7 +8780,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUncheckedCreateInput } from \\"./FirstModelUncheckedCreateInput\\";

--- a/tests/regression/__snapshots__/outputs.ts.snap
+++ b/tests/regression/__snapshots__/outputs.ts.snap
@@ -242,6 +242,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManyAndReturnExample } from \\"./UpdateManyAndReturnExample\\";
 "
 `;
 
@@ -487,6 +488,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManyAndReturnExample } from \\"./UpdateManyAndReturnExample\\";
 "
 `;
 
@@ -531,6 +533,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyAndReturnFirstModel } from \\"./UpdateManyAndReturnFirstModel\\";
+export { UpdateManyAndReturnSecondModel } from \\"./UpdateManyAndReturnSecondModel\\";
 export * from \\"./args\\";
 "
 `;
@@ -576,6 +580,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyAndReturnFirstModel } from \\"./UpdateManyAndReturnFirstModel\\";
+export { UpdateManyAndReturnSecondModel } from \\"./UpdateManyAndReturnSecondModel\\";
 export * from \\"./args\\";
 "
 `;
@@ -929,6 +935,7 @@ export { SampleGroupBy } from \\"./SampleGroupBy\\";
 export { SampleMaxAggregate } from \\"./SampleMaxAggregate\\";
 export { SampleMinAggregate } from \\"./SampleMinAggregate\\";
 export { SampleSumAggregate } from \\"./SampleSumAggregate\\";
+export { UpdateManyAndReturnSample } from \\"./UpdateManyAndReturnSample\\";
 "
 `;
 

--- a/tests/regression/__snapshots__/structure.ts.snap
+++ b/tests/regression/__snapshots__/structure.ts.snap
@@ -62,6 +62,8 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
         GroupByPostResolver.js
         PostCrudResolver.d.ts
         PostCrudResolver.js
+        UpdateManyAndReturnPostResolver.d.ts
+        UpdateManyAndReturnPostResolver.js
         UpdateManyPostResolver.d.ts
         UpdateManyPostResolver.js
         UpdateOnePostResolver.d.ts
@@ -93,6 +95,8 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
           FindUniquePostOrThrowArgs.js
           GroupByPostArgs.d.ts
           GroupByPostArgs.js
+          UpdateManyAndReturnPostArgs.d.ts
+          UpdateManyAndReturnPostArgs.js
           UpdateManyPostArgs.d.ts
           UpdateManyPostArgs.js
           UpdateOnePostArgs.d.ts
@@ -126,6 +130,8 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
         FindUniqueUserResolver.js
         GroupByUserResolver.d.ts
         GroupByUserResolver.js
+        UpdateManyAndReturnUserResolver.d.ts
+        UpdateManyAndReturnUserResolver.js
         UpdateManyUserResolver.d.ts
         UpdateManyUserResolver.js
         UpdateOneUserResolver.d.ts
@@ -159,6 +165,8 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
           FindUniqueUserOrThrowArgs.js
           GroupByUserArgs.d.ts
           GroupByUserArgs.js
+          UpdateManyAndReturnUserArgs.d.ts
+          UpdateManyAndReturnUserArgs.js
           UpdateManyUserArgs.d.ts
           UpdateManyUserArgs.js
           UpdateOneUserArgs.d.ts
@@ -298,8 +306,8 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
       UserOrderByWithAggregationInput.js
       UserOrderByWithRelationInput.d.ts
       UserOrderByWithRelationInput.js
-      UserRelationFilter.d.ts
-      UserRelationFilter.js
+      UserScalarRelationFilter.d.ts
+      UserScalarRelationFilter.js
       UserScalarWhereWithAggregatesInput.d.ts
       UserScalarWhereWithAggregatesInput.js
       UserSumOrderByAggregateInput.d.ts
@@ -345,6 +353,10 @@ exports[`structure should generate *.js and *.d.ts files when emitTranspiledCode
       PostMinAggregate.js
       PostSumAggregate.d.ts
       PostSumAggregate.js
+      UpdateManyAndReturnPost.d.ts
+      UpdateManyAndReturnPost.js
+      UpdateManyAndReturnUser.d.ts
+      UpdateManyAndReturnUser.js
       UserAvgAggregate.d.ts
       UserAvgAggregate.js
       UserCount.d.ts
@@ -424,6 +436,7 @@ exports[`structure should generate proper folders and file names when model is r
         FindUniqueRenamedPostResolver.ts
         GroupByRenamedPostResolver.ts
         RenamedPostCrudResolver.ts
+        UpdateManyAndReturnRenamedPostResolver.ts
         UpdateManyRenamedPostResolver.ts
         UpdateOneRenamedPostResolver.ts
         UpsertOneRenamedPostResolver.ts
@@ -440,6 +453,7 @@ exports[`structure should generate proper folders and file names when model is r
           FindUniqueRenamedPostArgs.ts
           FindUniqueRenamedPostOrThrowArgs.ts
           GroupByRenamedPostArgs.ts
+          UpdateManyAndReturnRenamedPostArgs.ts
           UpdateManyRenamedPostArgs.ts
           UpdateOneRenamedPostArgs.ts
           UpsertOneRenamedPostArgs.ts
@@ -458,6 +472,7 @@ exports[`structure should generate proper folders and file names when model is r
         FindUniqueRenamedUserResolver.ts
         GroupByRenamedUserResolver.ts
         RenamedUserCrudResolver.ts
+        UpdateManyAndReturnRenamedUserResolver.ts
         UpdateManyRenamedUserResolver.ts
         UpdateOneRenamedUserResolver.ts
         UpsertOneRenamedUserResolver.ts
@@ -474,6 +489,7 @@ exports[`structure should generate proper folders and file names when model is r
           FindUniqueRenamedUserArgs.ts
           FindUniqueRenamedUserOrThrowArgs.ts
           GroupByRenamedUserArgs.ts
+          UpdateManyAndReturnRenamedUserArgs.ts
           UpdateManyRenamedUserArgs.ts
           UpdateOneRenamedUserArgs.ts
           UpsertOneRenamedUserArgs.ts
@@ -538,7 +554,7 @@ exports[`structure should generate proper folders and file names when model is r
       RenamedUserMinOrderByAggregateInput.ts
       RenamedUserOrderByWithAggregationInput.ts
       RenamedUserOrderByWithRelationInput.ts
-      RenamedUserRelationFilter.ts
+      RenamedUserScalarRelationFilter.ts
       RenamedUserScalarWhereWithAggregatesInput.ts
       RenamedUserSumOrderByAggregateInput.ts
       RenamedUserUpdateInput.ts
@@ -575,6 +591,8 @@ exports[`structure should generate proper folders and file names when model is r
       RenamedUserMaxAggregate.ts
       RenamedUserMinAggregate.ts
       RenamedUserSumAggregate.ts
+      UpdateManyAndReturnRenamedPost.ts
+      UpdateManyAndReturnRenamedUser.ts
       [args]
         RenamedUserCountPostsArgs.ts
         index.ts
@@ -629,6 +647,7 @@ exports[`structure should generate proper folders structure and file names for c
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -645,6 +664,7 @@ exports[`structure should generate proper folders structure and file names for c
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -662,6 +682,7 @@ exports[`structure should generate proper folders structure and file names for c
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -679,6 +700,7 @@ exports[`structure should generate proper folders structure and file names for c
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -749,7 +771,7 @@ exports[`structure should generate proper folders structure and file names for c
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -773,6 +795,8 @@ exports[`structure should generate proper folders structure and file names for c
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts

--- a/tests/regression/inputs.ts
+++ b/tests/regression/inputs.ts
@@ -369,7 +369,7 @@ describe("inputs", () => {
       "/resolvers/inputs/FirstModelOrderByWithRelationInput.ts",
     );
     const firstModelRelationFilterTSFile = await readGeneratedFile(
-      "/resolvers/inputs/FirstModelRelationFilter.ts",
+      "/resolvers/inputs/FirstModelScalarRelationFilter.ts",
     );
     const secondModelWhereInputTSFile = await readGeneratedFile(
       "/resolvers/inputs/SecondModelWhereInput.ts",
@@ -996,7 +996,7 @@ describe("inputs", () => {
           "/resolvers/inputs/RenamedFirstModelOrderByWithRelationInput.ts",
         );
       const renamedFirstModelRelationFilterTSFile = await readGeneratedFile(
-        "/resolvers/inputs/RenamedFirstModelRelationFilter.ts",
+        "/resolvers/inputs/RenamedFirstModelScalarRelationFilter.ts",
       );
       const renamedSecondModelWhereInputTSFile = await readGeneratedFile(
         "/resolvers/inputs/RenamedSecondModelWhereInput.ts",


### PR DESCRIPTION
### Changes

* Added support for Prisma 6
* Removed support for Prisma 5
* New API: `createManyAndReturn` (this was already in 5.14.0, but the snapshots didn't have them yet)
* Ordering of `array_starts_with`, `array_ends_with` and `array_contains` changed somewhere, so the snapshots have been updated. Not a functional change.
* New field: `limit` on `DeleteMany` and `UpdateMany`.

### Workflow

This is how i approached this PR:

1. Update prisma in package.json, and ran the tests.
1. Tests gave typescript errors about the `FieldType`, which I resolved in `/src/generator/dmmf/types.ts`.
1. Everywhere where `createManyAndReturn` was mentioned, I also added `updateManyAndReturn`.
1. 2 snapshot tests where detected as "obsolete" (20 is just because it skipped after the first was errored) because files wheren't the correct name. For one, just the file name needed to be updated, but the second one required me to add `ScalarRelationFilter` to `src/generator/helpers.ts`. I'm not sure about this last change.
1. Updated the snapshots using `u` after running all the tests.

A bit harder where the integration tests. For those a working Postgres database is required:
1. Launch a DB using `sudo docker run --rm --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_DB=testing -d -p 5432:5432 postgres`
1. Create a `.env` file with `TEST_DATABASE_URL=postgresql://postgres:mysecretpassword@localhost:5432/testing`.
1. Run the tests with `npm run test:integration`
1. Updated all the snapshots using `u`. The changes is the same as mentioned above.

### Test results

Because I can't run tests on this repo, I also created a MR on my own repo to test my changes: https://github.com/RubenNL/typegraphql-prisma/pull/1.

# Help required

Most/all `*ModelRelationFilter` have been renamed to `*ModelScalarRelationFilter`. I can't figure out why, or how to undo this change.  
Related: I had to add `ScalarRelation` to `src/generator/helpers.ts`, because otherwise the "renamed" tests failed.