### PR TITLE
Update adding-fields.md

### DIFF
--- a/docs/advanced/adding-fields.md
+++ b/docs/advanced/adding-fields.md
@@ -3,9 +3,32 @@ title: Adding fields to model type
 sidebar_label: Adding model fields
 ---
 
-If you want to add a field to the generated type like `User`, you have to create a proper `@FieldResolver` for that:
+
+### Adding Custom Fields to a Generated Model
+
+By default, `typegraphql-prisma` generates GraphQL types directly from your Prisma schema. However, if you need to add fields to your GraphQL schema that **do not exist in your Prisma database schema**, you can define them as **computed fields**. These fields are dynamically resolved at runtime rather than stored in the database.  
+
+**Because of this, they cannot be used in Prisma queries for filtering or sorting.** Instead, you can use a `@FieldResolver` to compute them on demand.
+
+### Why Use `@FieldResolver`?
+
+`@FieldResolver` allows you to define **computed fields**—fields that are derived from existing data rather than being stored in the database. These fields are useful for:
+
+- Formatting or transforming existing fields  
+- Aggregating related data  
+- Resolving additional information dynamically  
+
+### Example: Adding a `favoritePost` Field to the `User` Model
+
+Let’s say you want to add a `favoritePost` field to the `User` type, which fetches the user's first post. This field does not exist in the Prisma schema but can be derived dynamically.
+
+Here’s how you can implement it:
 
 ```ts
+import { Resolver, FieldResolver, Root, Ctx } from "type-graphql";
+import { User, Post } from "@generated/type-graphql";
+import { Context } from "../context";
+
 @Resolver(of => User)
 export class CustomUserResolver {
   @FieldResolver(type => Post, { nullable: true })
@@ -13,11 +36,11 @@ export class CustomUserResolver {
     @Root() user: User,
     @Ctx() { prisma }: Context,
   ): Promise<Post | undefined> {
+    // Fetch the first post of the user
     const [favoritePost] = await prisma.user
       .findUniqueOrThrow({ where: { id: user.id } })
-      .posts({ first: 1 });
+      .posts({ take: 1 });
 
     return favoritePost;
   }
 }
-```


### PR DESCRIPTION
1. **Clarified the Purpose of Field Resolvers**  
   - Updated the introduction to explicitly state that `typegraphql-prisma` generates GraphQL types from the Prisma schema by default.  
   - Emphasized that additional fields added via `@FieldResolver` are **not stored in the database** and are computed dynamically.  
   - Highlighted a key limitation: **these fields cannot be used in Prisma queries for filtering or sorting.**  

2. **Fixed Incorrect Prisma Query Syntax**  
   - Replaced **`first: 1`** with **`take: 1`** in the Prisma query.  
   - **Reason:** Prisma does not support `first`, and `take` is the correct way to limit results when fetching related records.  

3. **Improved Code Readability and Structure**  
   - Ensured the example clearly follows best practices.  
   - Kept variable names meaningful for better understanding.  

4. **Provided Additional Explanation**  
   - Added a breakdown of why `@FieldResolver` is necessary.  
   - Explained the **difference between Prisma fields and computed fields** in the GraphQL schema.  

These improvements make the documentation clearer, ensuring that developers understand why and how to use `@FieldResolver` effectively in a `typegraphql-prisma` project.
