### PR TITLE
feat: Update fullTextSearch to fullTextSearchPostgres

### DIFF
--- a/experiments/postgres/prisma/schema.prisma
+++ b/experiments/postgres/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
   provider        = "prisma-client-js"
   // binaryTargets   = ["windows", "debian-openssl-1.1.x"]
   output          = "../prisma/generated/client"
-  previewFeatures = ["fullTextSearch"]
+  previewFeatures = ["fullTextSearchPostgres"]
 }
 
 generator typegraphql {

--- a/tests/helpers/generate-code.ts
+++ b/tests/helpers/generate-code.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src/generator/options";
 import getPrismaClientDmmfFromPrismaSchema from "./dmmf";
 
-type SupportedPreviewFeatures = "fullTextSearch";
+type SupportedPreviewFeatures = "fullTextSearchPostgres";
 
 interface GenerateCodeFromSchemaOptions
   extends Omit<

--- a/tests/regression/__snapshots__/enums.ts.snap
+++ b/tests/regression/__snapshots__/enums.ts.snap
@@ -197,7 +197,7 @@ export { TransactionIsolationLevel } from \\"./TransactionIsolationLevel\\";
 "
 `;
 
-exports[`enums when \`fullTextSearch\` preview feature is enabled should properly generate enums for relevance: SampleModelOrderByRelevanceFieldEnum 1`] = `
+exports[`enums when \`fullTextSearchPostgres\` preview feature is enabled should properly generate enums for relevance: SampleModelOrderByRelevanceFieldEnum 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 
 export enum SampleModelOrderByRelevanceFieldEnum {
@@ -210,7 +210,7 @@ TypeGraphQL.registerEnumType(SampleModelOrderByRelevanceFieldEnum, {
 "
 `;
 
-exports[`enums when \`fullTextSearch\` preview feature is enabled when model is renamed should properly generate enums for relevance: SampleRenamedModelOrderByRelevanceFieldEnum 1`] = `
+exports[`enums when \`fullTextSearchPostgres\` preview feature is enabled when model is renamed should properly generate enums for relevance: SampleRenamedModelOrderByRelevanceFieldEnum 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 
 export enum SampleRenamedModelOrderByRelevanceFieldEnum {

--- a/tests/regression/__snapshots__/inputs.ts.snap
+++ b/tests/regression/__snapshots__/inputs.ts.snap
@@ -6767,7 +6767,7 @@ export class FirstModelWhereUniqueInput {
 "
 `;
 
-exports[`inputs when \`fullTextSearch\` preview feature is enabled should properly generate input type classes with relevance and string search field: FirstModelOrderByRelevanceInput 1`] = `
+exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled should properly generate input type classes with relevance and string search field: FirstModelOrderByRelevanceInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
@@ -6795,7 +6795,7 @@ export class FirstModelOrderByRelevanceInput {
 "
 `;
 
-exports[`inputs when \`fullTextSearch\` preview feature is enabled should properly generate input type classes with relevance and string search field: FirstModelOrderByWithRelationInput 1`] = `
+exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled should properly generate input type classes with relevance and string search field: FirstModelOrderByWithRelationInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
@@ -6834,7 +6834,7 @@ export class FirstModelOrderByWithRelationInput {
 "
 `;
 
-exports[`inputs when \`fullTextSearch\` preview feature is enabled should properly generate input type classes with relevance and string search field: NestedStringFilter 1`] = `
+exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled should properly generate input type classes with relevance and string search field: NestedStringFilter 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
@@ -6905,7 +6905,7 @@ export class NestedStringFilter {
 "
 `;
 
-exports[`inputs when \`fullTextSearch\` preview feature is enabled should properly generate input type classes with relevance and string search field: StringFilter 1`] = `
+exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled should properly generate input type classes with relevance and string search field: StringFilter 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
@@ -6983,7 +6983,7 @@ export class StringFilter {
 "
 `;
 
-exports[`inputs when \`fullTextSearch\` preview feature is enabled should properly generate input type classes with relevance and string search field: index 1`] = `
+exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled should properly generate input type classes with relevance and string search field: index 1`] = `
 "export { FirstModelAvgOrderByAggregateInput } from \\"./FirstModelAvgOrderByAggregateInput\\";
 export { FirstModelCountOrderByAggregateInput } from \\"./FirstModelCountOrderByAggregateInput\\";
 export { FirstModelCreateInput } from \\"./FirstModelCreateInput\\";

--- a/tests/regression/__snapshots__/relations.ts.snap
+++ b/tests/regression/__snapshots__/relations.ts.snap
@@ -640,7 +640,7 @@ export class UserRelationsResolver {
 "
 `;
 
-exports[`relations resolvers generation when \`fullTextSearch\` preview feature is enabled should properly generate args type classes using SearchRelevanceInput: FirstModelSecondModelsFieldArgs 1`] = `
+exports[`relations resolvers generation when \`fullTextSearchPostgres\` preview feature is enabled should properly generate args type classes using SearchRelevanceInput: FirstModelSecondModelsFieldArgs 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { SecondModelOrderByWithRelationInput } from \\"../../../inputs/SecondModelOrderByWithRelationInput\\";

--- a/tests/regression/enums.ts
+++ b/tests/regression/enums.ts
@@ -151,7 +151,7 @@ describe("enums", () => {
     expect(enumsIndexTSFile).toMatchSnapshot("enums index");
   });
 
-  describe("when `fullTextSearch` preview feature is enabled", () => {
+  describe("when `fullTextSearchPostgres` preview feature is enabled", () => {
     it("should properly generate enums for relevance", async () => {
       const schema = /* prisma */ `
         model SampleModel {
@@ -161,10 +161,14 @@ describe("enums", () => {
         }
       `;
 
-      await generateCodeFromSchema(schema, {
-        outputDirPath,
-        previewFeatures: ["fullTextSearch"],
-      });
+      await generateCodeFromSchema(
+        schema,
+        {
+          outputDirPath,
+          previewFeatures: ["fullTextSearchPostgres"],
+        },
+        "postgresql",
+      );
       const sampleModelOrderByRelevanceFieldEnumTSFile =
         await readGeneratedFile(
           "/enums/SampleModelOrderByRelevanceFieldEnum.ts",
@@ -186,10 +190,14 @@ describe("enums", () => {
           }
         `;
 
-        await generateCodeFromSchema(schema, {
-          outputDirPath,
-          previewFeatures: ["fullTextSearch"],
-        });
+        await generateCodeFromSchema(
+          schema,
+          {
+            outputDirPath,
+            previewFeatures: ["fullTextSearchPostgres"],
+          },
+          "postgresql",
+        );
         const sampleRenamedModelOrderByRelevanceFieldEnumTSFile =
           await readGeneratedFile(
             "/enums/SampleRenamedModelOrderByRelevanceFieldEnum.ts",

--- a/tests/regression/inputs.ts
+++ b/tests/regression/inputs.ts
@@ -1371,7 +1371,7 @@ describe("inputs", () => {
     expect(indexTSFile).toMatchSnapshot("index");
   });
 
-  describe("when `fullTextSearch` preview feature is enabled", () => {
+  describe("when `fullTextSearchPostgres` preview feature is enabled", () => {
     it("should properly generate input type classes with relevance and string search field", async () => {
       const schema = /* prisma */ `
         model FirstModel {
@@ -1389,10 +1389,14 @@ describe("inputs", () => {
         }
       `;
 
-      await generateCodeFromSchema(schema, {
-        outputDirPath,
-        previewFeatures: ["fullTextSearch"],
-      });
+      await generateCodeFromSchema(
+        schema,
+        {
+          outputDirPath,
+          previewFeatures: ["fullTextSearchPostgres"],
+        },
+        "postgresql",
+      );
       const orderByRelevanceInputTSFile = await readGeneratedFile(
         "/resolvers/inputs/FirstModelOrderByRelevanceInput.ts",
       );

--- a/tests/regression/relations.ts
+++ b/tests/regression/relations.ts
@@ -453,7 +453,7 @@ describe("relations resolvers generation", () => {
     expect(mainIndexTSFile).toMatchSnapshot("mainIndex");
   });
 
-  describe("when `fullTextSearch` preview feature is enabled", () => {
+  describe("when `fullTextSearchPostgres` preview feature is enabled", () => {
     it("should properly generate args type classes using SearchRelevanceInput", async () => {
       const schema = /* prisma */ `
         model FirstModel {
@@ -471,10 +471,14 @@ describe("relations resolvers generation", () => {
         }
       `;
 
-      await generateCodeFromSchema(schema, {
-        outputDirPath,
-        previewFeatures: ["fullTextSearch"],
-      });
+      await generateCodeFromSchema(
+        schema,
+        {
+          outputDirPath,
+          previewFeatures: ["fullTextSearchPostgres"],
+        },
+        "postgresql",
+      );
       const firstModelSecondModelsFieldArgsTSFile = await readGeneratedFile(
         "/resolvers/relations/FirstModel/args/FirstModelSecondModelsFieldArgs.ts",
       );


### PR DESCRIPTION
This commit updates the preview feature flag for full-text search on PostgreSQL from `fullTextSearch` to the new `fullTextSearchPostgres`.

The changes include:
- Updating the `previewFeatures` in the experimental `schema.prisma`.
- Removing the deprecated `fullTextSearch` from the supported preview features in the test helper.
- Updating all relevant tests and test snapshots to use `fullTextSearchPostgres` and the "postgresql" provider.