### PR TITLE
update: support prisma version 6.19

### DIFF
--- a/docs/basics/configuration.md
+++ b/docs/basics/configuration.md
@@ -24,6 +24,16 @@ generator typegraphql {
 
 Then run `npx prisma generate` - this will emit the generated TypeGraphQL classes to the `@generated/type-graphql` folder inside `node_modules`.
 
+## Supported Prisma client providers
+
+`typegraphql-prisma` supports Prisma client generators with these providers:
+
+- `prisma-client-js`
+- `prisma-client`
+- `prisma-client-ts`
+
+When using `prisma-client` or `prisma-client-ts`, remember to configure explicit `output` path for the Prisma client generator.
+
 ## Changing output folder
 
 When you want to emit the generated files into a different folder, you can configure the default output folder via the `output` config option, e.g.:

--- a/docs/basics/installation.md
+++ b/docs/basics/installation.md
@@ -30,9 +30,9 @@ npm i @prisma/client
 
 :::caution
 Be aware that `typegraphql-prisma` is designed to work with a selected versions of Prisma.
-This generator is designed to work and tested with the features of the `5.0.0` release.
+This generator is designed to work and tested with Prisma `6.19.x`.
 
-You can update both `prisma` and `@prisma/client` to a newer version, matching `^5.0.0`, like `5.4.2`, in order to receive important bugfixes.
+You can update both `prisma` and `@prisma/client` to a newer version matching `^6.19.0`, in order to receive important bugfixes.
 However, make sure you don't use the new features from a newer Prisma version, especially the ones behind a preview flag.
 
 If you encounter a new Prisma feature not supported yet, please check on GitHub issues and create a new issue, if that wasn't already reported, and downgrade the Prisma version, if needed.

--- a/docs/basics/prisma-version.md
+++ b/docs/basics/prisma-version.md
@@ -11,9 +11,9 @@ By default, it checks if the installed Prisma version matches the required one u
 So when you try to use other version, like a just published, new minor release (or the `dev` one), you will receive an error about wrong package version, e.g:
 
 ```sh
-Error: Looks like an incorrect version "3.1.1" of the Prisma packages has been installed.
+Error: Looks like an incorrect version "6.18.0" of the Prisma packages has been installed.
 'typegraphql-prisma' works only with selected versions, so please ensure
-that you have installed a version of Prisma that meets the requirement: "~3.0.1".
+that you have installed a version of Prisma that meets the requirement: "^6.19.0".
 Find out more about that requirement in docs:
 https://prisma.typegraphql.com/docs/basics/prisma-version
 ```

--- a/docs/basics/usage.md
+++ b/docs/basics/usage.md
@@ -111,6 +111,7 @@ However, it can also generate some resolvers which might be handy especially on 
 - createManyAndReturn
 - update
 - updateMany
+- updateManyAndReturn
 - delete
 - deleteMany
 - upsert

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/generator-helper": "^5.18.0",
-        "@prisma/internals": "^5.18.0",
+        "@prisma/dmmf": "^6.19.0",
+        "@prisma/generator": "^6.19.0",
+        "@prisma/generator-helper": "^6.19.0",
+        "@prisma/internals": "^6.19.0",
         "pluralize": "^8.0.0",
         "semver": "^7.6.3",
         "ts-morph": "^23.0.0",
@@ -21,7 +23,7 @@
       },
       "devDependencies": {
         "@jest/types": "^29.6.3",
-        "@prisma/client": "^5.18.0",
+        "@prisma/client": "^6.19.0",
         "@types/graphql-fields": "^1.3.9",
         "@types/jest": "^29.5.12",
         "@types/node": "^22.1.0",
@@ -40,7 +42,7 @@
         "pg": "^8.12.0",
         "prettier": "^3.3.3",
         "prettier-2": "npm:prettier@^2",
-        "prisma": "^5.18.0",
+        "prisma": "^6.19.0",
         "reflect-metadata": "0.1.13",
         "ts-jest": "~29.2.4",
         "ts-node": "^10.9.2",
@@ -53,12 +55,12 @@
         "node": ">=20.11.1"
       },
       "peerDependencies": {
-        "@prisma/client": "^5.18.0",
+        "@prisma/client": "^6.19.0",
         "@types/graphql-fields": "^1.3.9",
         "@types/node": "*",
         "graphql-fields": "^2.0.3",
         "graphql-scalars": "^1.23.0",
-        "prisma": "^5.18.0",
+        "prisma": "^6.19.0",
         "tslib": "^2.6.3",
         "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
       }
@@ -1161,85 +1163,145 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.18.0.tgz",
-      "integrity": "sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
+      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
-        "prisma": "*"
+        "prisma": "*",
+        "typescript": ">=5.1.0"
       },
       "peerDependenciesMeta": {
         "prisma": {
           "optional": true
+        },
+        "typescript": {
+          "optional": true
         }
       }
     },
+    "node_modules/@prisma/config": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
+      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
     "node_modules/@prisma/debug": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.18.0.tgz",
-      "integrity": "sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw=="
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
+      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dmmf": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/dmmf/-/dmmf-6.19.2.tgz",
+      "integrity": "sha512-ZHGDQlnrWKwFPAOvJ8hVbmIqNPdE0XXptTeYqmUGhYMDySSts60O8g3KNY1uAqr3nHiyDcpaGIpO1MBYoDW6gQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.19.2.tgz",
+      "integrity": "sha512-tkHsL3jhx81eXg2oqtJH/1IEs8uEeUb1RpqHtwYqdNb176u9D0mnHRZM1/cKca/XhLpq49Nnd9XDxdMfWcKAYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.2"
+      }
     },
     "node_modules/@prisma/engines": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.18.0.tgz",
-      "integrity": "sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
+      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.2",
+        "@prisma/get-platform": "6.19.2"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg=="
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz",
-      "integrity": "sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
+      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.2"
       }
     },
+    "node_modules/@prisma/generator": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/generator/-/generator-6.19.2.tgz",
+      "integrity": "sha512-2xDQQUJh2s6Ty9I9CIGRz7Z8pEGxKxjU/lkFyLI5f83fDoISUaGhWQZGW35xMqKVDoNRM93w1ghm+1ScRy0mAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/generator-helper": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.18.0.tgz",
-      "integrity": "sha512-3ffmrd9KE8ssg/fwyvfwMxrDAunLF8DLFjfwYnDRE7VaNIhkUVZwB77jAwpMCtukvCsAp14WGWu4itvLMzH3GQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-6.19.2.tgz",
+      "integrity": "sha512-vSjDbHhtKjRDgywTDYyAJLEe+kMxq4DNLNiurk/tGca8W/H7duX4Z4UdvYXcv3kWmmgJJmdndh41dgIsrewa3w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/dmmf": "6.19.2",
+        "@prisma/generator": "6.19.2"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.18.0.tgz",
-      "integrity": "sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
+      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.19.2"
       }
     },
     "node_modules/@prisma/internals": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-5.18.0.tgz",
-      "integrity": "sha512-NYG69q0FxpPHXDtEM2GS5kU22IwgtriCceNH00dWP9dV7oHz23+8QWJMlDsICTR7gnULLCeS2gWBuXWTS1PRmA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-6.19.2.tgz",
+      "integrity": "sha512-ciXNy15WKIg4rjuA0dNZ03CMJEneoEi47a3E6Yp59KI90M7r/nieaiqSRtWakl9nKj2YKfRX6nraYC3zaeSQXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines": "5.18.0",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/generator-helper": "5.18.0",
-        "@prisma/get-platform": "5.18.0",
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/schema-files-loader": "5.18.0",
+        "@prisma/config": "6.19.2",
+        "@prisma/debug": "6.19.2",
+        "@prisma/dmmf": "6.19.2",
+        "@prisma/driver-adapter-utils": "6.19.2",
+        "@prisma/engines": "6.19.2",
+        "@prisma/fetch-engine": "6.19.2",
+        "@prisma/generator": "6.19.2",
+        "@prisma/generator-helper": "6.19.2",
+        "@prisma/get-platform": "6.19.2",
+        "@prisma/prisma-schema-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/schema-engine-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/schema-files-loader": "6.19.2",
         "arg": "5.0.2",
         "prompts": "2.4.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@prisma/internals/node_modules/arg": {
@@ -1247,17 +1309,25 @@
       "license": "MIT"
     },
     "node_modules/@prisma/prisma-schema-wasm": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-2h7MDiYVXHVSdz0CylOUktVouPHRKUw5ciXz2r/oZsO2T6Zycez/eSvh4SKiKbHuxDq6SSb3R97mO7bjzh+NVQ=="
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-/5JrsJQAOIWSl+9WMM/0ugd737kT9zdMNr7EFaP7ogeMxAhxQ78uaOV6JYGEocD8LC0gZx7MXmVE/CTfYdJ2iA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/schema-engine-wasm": {
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-engine-wasm/-/schema-engine-wasm-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-mXtzeePkSdqpr/HAIclqzQEf+tBzLawy7NQ9AaRCfg8N/cruavpsocgbSwOOfV7JTk9JubyzKuR3tp2bNNuWbQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/schema-files-loader": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-5.18.0.tgz",
-      "integrity": "sha512-JtjPOZ8odMMr3etCcQ5kDsuljmckuNNCRMJglouPWSyzRbv4nOQJZCD4qPmoMUSoX0gwV7wGgwUw50XsoFYVzA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.2.tgz",
+      "integrity": "sha512-v4dHwmYn0rsn6E6Lo6EH4oT7rYVlbJTKWUL3j4gjX0AyQefm3NIITFdYuonDy1S4y2Z/3D1r8gCVjFLskKfK/A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "fs-extra": "11.1.1"
+        "@prisma/prisma-schema-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "fs-extra": "11.3.0"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -1289,6 +1359,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@ts-morph/common": {
       "version": "0.24.0",
@@ -1837,6 +1913,34 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1895,6 +1999,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -1910,24 +2029,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
-    },
-    "node_modules/class-validator": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
-      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/validator": "^13.7.10",
-        "libphonenumber-js": "^1.10.14",
-        "validator": "^13.7.0"
-      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -2198,6 +2313,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2296,6 +2426,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2338,6 +2489,28 @@
         "node": ">=10.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2375,6 +2548,15 @@
       "version": "8.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/env-cmd": {
       "version": "10.1.0",
@@ -2502,6 +2684,34 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -2592,9 +2802,10 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2671,6 +2882,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob": {
@@ -3587,6 +3815,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "dev": true,
@@ -3635,9 +3872,10 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -3660,14 +3898,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.10.28",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.28.tgz",
-      "integrity": "sha512-1eAgjLrZA0+2Wgw4hs+4Q/kEBycxQo8ZLYnmOvZ3AlM8ImAVAJgDPlZtISLEzD1vunc2q8s2Pn7XwB7I8U3Kzw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.2",
@@ -4086,6 +4316,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4117,11 +4353,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "license": "MIT"
+    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -4216,6 +4481,18 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -4413,6 +4690,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "license": "MIT",
@@ -4519,19 +4807,29 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.18.0.tgz",
-      "integrity": "sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
+      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.18.0"
+        "@prisma/config": "6.19.2",
+        "@prisma/engines": "6.19.2"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/prompts": {
@@ -4546,10 +4844,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "funding": [
         {
           "type": "individual",
@@ -4559,7 +4856,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4580,6 +4878,16 @@
         }
       ]
     },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -4597,6 +4905,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/reduce-flatten": {
@@ -5043,6 +5364,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5231,7 +5561,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5258,6 +5588,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -5310,16 +5641,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/validator": {
-      "version": "13.7.0",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/walker": {
@@ -6378,71 +6699,107 @@
       }
     },
     "@prisma/client": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.18.0.tgz",
-      "integrity": "sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.2.tgz",
+      "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "dev": true,
       "requires": {}
     },
+    "@prisma/config": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.2.tgz",
+      "integrity": "sha512-kadBGDl+aUswv/zZMk9Mx0C8UZs1kjao8H9/JpI4Wh4SHZaM7zkTwiKn/iFLfRg+XtOAo/Z/c6pAYhijKl0nzQ==",
+      "requires": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
     "@prisma/debug": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.18.0.tgz",
-      "integrity": "sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw=="
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.2.tgz",
+      "integrity": "sha512-lFnEZsLdFLmEVCVNdskLDCL8Uup41GDfU0LUfquw+ercJC8ODTuL0WNKgOKmYxCJVvFwf0OuZBzW99DuWmoH2A=="
+    },
+    "@prisma/dmmf": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/dmmf/-/dmmf-6.19.2.tgz",
+      "integrity": "sha512-ZHGDQlnrWKwFPAOvJ8hVbmIqNPdE0XXptTeYqmUGhYMDySSts60O8g3KNY1uAqr3nHiyDcpaGIpO1MBYoDW6gQ=="
+    },
+    "@prisma/driver-adapter-utils": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-6.19.2.tgz",
+      "integrity": "sha512-tkHsL3jhx81eXg2oqtJH/1IEs8uEeUb1RpqHtwYqdNb176u9D0mnHRZM1/cKca/XhLpq49Nnd9XDxdMfWcKAYA==",
+      "requires": {
+        "@prisma/debug": "6.19.2"
+      }
     },
     "@prisma/engines": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.18.0.tgz",
-      "integrity": "sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.2.tgz",
+      "integrity": "sha512-TTkJ8r+uk/uqczX40wb+ODG0E0icVsMgwCTyTHXehaEfb0uo80M9g1aW1tEJrxmFHeOZFXdI2sTA1j1AgcHi4A==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.2",
+        "@prisma/get-platform": "6.19.2"
       }
     },
     "@prisma/engines-version": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg=="
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA=="
     },
     "@prisma/fetch-engine": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz",
-      "integrity": "sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.2.tgz",
+      "integrity": "sha512-h4Ff4Pho+SR1S8XerMCC12X//oY2bG3Iug/fUnudfcXEUnIeRiBdXHFdGlGOgQ3HqKgosTEhkZMvGM9tWtYC+Q==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/get-platform": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.2"
       }
     },
+    "@prisma/generator": {
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/generator/-/generator-6.19.2.tgz",
+      "integrity": "sha512-2xDQQUJh2s6Ty9I9CIGRz7Z8pEGxKxjU/lkFyLI5f83fDoISUaGhWQZGW35xMqKVDoNRM93w1ghm+1ScRy0mAA=="
+    },
     "@prisma/generator-helper": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.18.0.tgz",
-      "integrity": "sha512-3ffmrd9KE8ssg/fwyvfwMxrDAunLF8DLFjfwYnDRE7VaNIhkUVZwB77jAwpMCtukvCsAp14WGWu4itvLMzH3GQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-6.19.2.tgz",
+      "integrity": "sha512-vSjDbHhtKjRDgywTDYyAJLEe+kMxq4DNLNiurk/tGca8W/H7duX4Z4UdvYXcv3kWmmgJJmdndh41dgIsrewa3w==",
       "requires": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.19.2",
+        "@prisma/dmmf": "6.19.2",
+        "@prisma/generator": "6.19.2"
       }
     },
     "@prisma/get-platform": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.18.0.tgz",
-      "integrity": "sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.2.tgz",
+      "integrity": "sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==",
       "requires": {
-        "@prisma/debug": "5.18.0"
+        "@prisma/debug": "6.19.2"
       }
     },
     "@prisma/internals": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-5.18.0.tgz",
-      "integrity": "sha512-NYG69q0FxpPHXDtEM2GS5kU22IwgtriCceNH00dWP9dV7oHz23+8QWJMlDsICTR7gnULLCeS2gWBuXWTS1PRmA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/internals/-/internals-6.19.2.tgz",
+      "integrity": "sha512-ciXNy15WKIg4rjuA0dNZ03CMJEneoEi47a3E6Yp59KI90M7r/nieaiqSRtWakl9nKj2YKfRX6nraYC3zaeSQXQ==",
       "requires": {
-        "@prisma/debug": "5.18.0",
-        "@prisma/engines": "5.18.0",
-        "@prisma/fetch-engine": "5.18.0",
-        "@prisma/generator-helper": "5.18.0",
-        "@prisma/get-platform": "5.18.0",
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "@prisma/schema-files-loader": "5.18.0",
+        "@prisma/config": "6.19.2",
+        "@prisma/debug": "6.19.2",
+        "@prisma/dmmf": "6.19.2",
+        "@prisma/driver-adapter-utils": "6.19.2",
+        "@prisma/engines": "6.19.2",
+        "@prisma/fetch-engine": "6.19.2",
+        "@prisma/generator": "6.19.2",
+        "@prisma/generator-helper": "6.19.2",
+        "@prisma/get-platform": "6.19.2",
+        "@prisma/prisma-schema-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/schema-engine-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/schema-files-loader": "6.19.2",
         "arg": "5.0.2",
         "prompts": "2.4.2"
       },
@@ -6453,17 +6810,22 @@
       }
     },
     "@prisma/prisma-schema-wasm": {
-      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
-      "integrity": "sha512-2h7MDiYVXHVSdz0CylOUktVouPHRKUw5ciXz2r/oZsO2T6Zycez/eSvh4SKiKbHuxDq6SSb3R97mO7bjzh+NVQ=="
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-/5JrsJQAOIWSl+9WMM/0ugd737kT9zdMNr7EFaP7ogeMxAhxQ78uaOV6JYGEocD8LC0gZx7MXmVE/CTfYdJ2iA=="
+    },
+    "@prisma/schema-engine-wasm": {
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-engine-wasm/-/schema-engine-wasm-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-mXtzeePkSdqpr/HAIclqzQEf+tBzLawy7NQ9AaRCfg8N/cruavpsocgbSwOOfV7JTk9JubyzKuR3tp2bNNuWbQ=="
     },
     "@prisma/schema-files-loader": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-5.18.0.tgz",
-      "integrity": "sha512-JtjPOZ8odMMr3etCcQ5kDsuljmckuNNCRMJglouPWSyzRbv4nOQJZCD4qPmoMUSoX0gwV7wGgwUw50XsoFYVzA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.2.tgz",
+      "integrity": "sha512-v4dHwmYn0rsn6E6Lo6EH4oT7rYVlbJTKWUL3j4gjX0AyQefm3NIITFdYuonDy1S4y2Z/3D1r8gCVjFLskKfK/A==",
       "requires": {
-        "@prisma/prisma-schema-wasm": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
-        "fs-extra": "11.1.1"
+        "@prisma/prisma-schema-wasm": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "fs-extra": "11.3.0"
       }
     },
     "@repeaterjs/repeater": {
@@ -6495,6 +6857,11 @@
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
     },
     "@ts-morph/common": {
       "version": "0.24.0",
@@ -6928,6 +7295,25 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "requires": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6960,30 +7346,33 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "requires": {
+        "readdirp": "^4.0.1"
+      }
+    },
     "ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
+    "citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "requires": {
+        "consola": "^3.2.3"
+      }
+    },
     "cjs-module-lexer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
-    },
-    "class-validator": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
-      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/validator": "^13.7.10",
-        "libphonenumber-js": "^1.10.14",
-        "validator": "^13.7.0"
-      }
     },
     "cli-cursor": {
       "version": "5.0.0",
@@ -7174,6 +7563,16 @@
       "version": "0.0.1",
       "dev": true
     },
+    "confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="
+    },
+    "consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="
+    },
     "convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7240,6 +7639,21 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
+    "deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="
+    },
+    "defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+    },
+    "destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -7266,6 +7680,20 @@
         "command-line-usage": "^6.1.1"
       }
     },
+    "dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
+    },
+    "effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "requires": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -7290,6 +7718,11 @@
     "emoji-regex": {
       "version": "8.0.0",
       "dev": true
+    },
+    "empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="
     },
     "env-cmd": {
       "version": "10.1.0",
@@ -7374,6 +7807,19 @@
         "jest-util": "^29.7.0"
       }
     },
+    "exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="
+    },
+    "fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "requires": {
+        "pure-rand": "^6.1.0"
+      }
+    },
     "fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -7452,9 +7898,9 @@
       }
     },
     "fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -7499,6 +7945,19 @@
     "get-stream": {
       "version": "6.0.1",
       "dev": true
+    },
+    "giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "requires": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      }
     },
     "glob": {
       "version": "7.2.3",
@@ -8170,6 +8629,11 @@
         }
       }
     },
+    "jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "dev": true
@@ -8201,9 +8665,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -8217,14 +8681,6 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
-    },
-    "libphonenumber-js": {
-      "version": "1.10.28",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.28.tgz",
-      "integrity": "sha512-1eAgjLrZA0+2Wgw4hs+4Q/kEBycxQo8ZLYnmOvZ3AlM8ImAVAJgDPlZtISLEzD1vunc2q8s2Pn7XwB7I8U3Kzw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "lilconfig": {
       "version": "3.1.2",
@@ -8490,6 +8946,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8513,11 +8974,33 @@
         "path-key": "^3.0.0"
       }
     },
+    "nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "requires": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "dependencies": {
+        "citty": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+          "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="
+        }
+      }
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
+    },
+    "ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -8574,6 +9057,16 @@
     "path-parse": {
       "version": "1.0.7",
       "dev": true
+    },
+    "pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
     },
     "pg": {
       "version": "8.12.0",
@@ -8710,6 +9203,16 @@
         }
       }
     },
+    "pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "requires": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "pluralize": {
       "version": "8.0.0"
     },
@@ -8770,12 +9273,13 @@
       }
     },
     "prisma": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.18.0.tgz",
-      "integrity": "sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.2.tgz",
+      "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "5.18.0"
+        "@prisma/config": "6.19.2",
+        "@prisma/engines": "6.19.2"
       }
     },
     "prompts": {
@@ -8786,15 +9290,23 @@
       }
     },
     "pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
-      "dev": true
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="
     },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "requires": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
     },
     "react-is": {
       "version": "18.2.0",
@@ -8810,6 +9322,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
     "reduce-flatten": {
       "version": "2.0.0",
@@ -9101,6 +9618,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -9204,7 +9726,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true
+      "devOptional": true
     },
     "typical": {
       "version": "4.0.0",
@@ -9249,12 +9771,6 @@
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^2.0.0"
       }
-    },
-    "validator": {
-      "version": "13.7.0",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -19,18 +19,20 @@
     "typegraphql-prisma": "lib/generator.js"
   },
   "peerDependencies": {
-    "@prisma/client": "^5.18.0",
+    "@prisma/client": "^6.19.0",
     "@types/graphql-fields": "^1.3.9",
     "@types/node": "*",
     "graphql-fields": "^2.0.3",
     "graphql-scalars": "^1.23.0",
-    "prisma": "^5.18.0",
+    "prisma": "^6.19.0",
     "tslib": "^2.6.3",
     "type-graphql": "^1.1.1 || >=1.2.0-rc || >=2.0.0-beta || >=2.0.0-rc"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^5.18.0",
-    "@prisma/internals": "^5.18.0",
+    "@prisma/dmmf": "^6.19.0",
+    "@prisma/generator": "^6.19.0",
+    "@prisma/generator-helper": "^6.19.0",
+    "@prisma/internals": "^6.19.0",
     "pluralize": "^8.0.0",
     "semver": "^7.6.3",
     "ts-morph": "^23.0.0",
@@ -38,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",
-    "@prisma/client": "^5.18.0",
+    "@prisma/client": "^6.19.0",
     "@types/graphql-fields": "^1.3.9",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.1.0",
@@ -57,7 +59,7 @@
     "pg": "^8.12.0",
     "prettier": "^3.3.3",
     "prettier-2": "npm:prettier@^2",
-    "prisma": "^5.18.0",
+    "prisma": "^6.19.0",
     "reflect-metadata": "0.1.13",
     "ts-jest": "~29.2.4",
     "ts-node": "^10.9.2",

--- a/src/cli/generator.ts
+++ b/src/cli/generator.ts
@@ -6,7 +6,6 @@ generatorHandler({
   onManifest: () => ({
     defaultOutput: "node_modules/@generated/type-graphql",
     prettyName: "TypeGraphQL integration",
-    requiresGenerators: ["prisma-client-js"],
   }),
   onGenerate: generate,
 });

--- a/src/cli/prisma-generator.ts
+++ b/src/cli/prisma-generator.ts
@@ -1,4 +1,4 @@
-import { GeneratorOptions } from "@prisma/generator-helper";
+import type { GeneratorOptions } from "@prisma/generator";
 import { getDMMF, parseEnvValue } from "@prisma/internals";
 import { promises as asyncFs } from "fs";
 import path from "path";
@@ -18,13 +18,31 @@ import {
 } from "./helpers";
 
 export async function generate(options: GeneratorOptions) {
+  const supportedPrismaClientProviders = [
+    "prisma-client-js",
+    "prisma-client",
+    "prisma-client-ts",
+  ] as const;
   const outputDir = parseEnvValue(options.generator.output!);
   await asyncFs.mkdir(outputDir, { recursive: true });
   await removeDir(outputDir, true);
 
   const prismaClientProvider = options.otherGenerators.find(
-    it => parseEnvValue(it.provider) === "prisma-client-js",
-  )!;
+    it =>
+      supportedPrismaClientProviders.includes(
+        parseEnvValue(it.provider) as (typeof supportedPrismaClientProviders)[number],
+      ),
+  );
+  if (!prismaClientProvider) {
+    const detectedProviders = options.otherGenerators.map(it =>
+      parseEnvValue(it.provider),
+    );
+    throw new Error(
+      `Could not find a supported Prisma Client generator. ` +
+        `Expected one of: ${supportedPrismaClientProviders.join(", ")}. ` +
+        `Detected providers: ${detectedProviders.join(", ") || "(none)"}.`,
+    );
+  }
   const prismaClientPath = parseEnvValue(prismaClientProvider.output!);
   const prismaClientDmmf = await getDMMF({
     datamodel: options.datamodel,

--- a/src/generator/config.ts
+++ b/src/generator/config.ts
@@ -26,6 +26,7 @@ export const supportedMutationActions = [
   "updateOne",
   "deleteMany",
   "updateMany",
+  "updateManyAndReturn",
   "upsertOne",
 ] satisfies (keyof typeof DMMF.ModelAction)[];
 export type SupportedMutations = (typeof supportedMutationActions)[number];

--- a/src/generator/dmmf/dmmf-document.ts
+++ b/src/generator/dmmf/dmmf-document.ts
@@ -1,4 +1,4 @@
-import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
+import type * as PrismaDMMF from "@prisma/dmmf";
 import { DMMF } from "./types";
 import {
   transformSchema,

--- a/src/generator/dmmf/transform.ts
+++ b/src/generator/dmmf/transform.ts
@@ -1,4 +1,4 @@
-import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
+import type * as PrismaDMMF from "@prisma/dmmf";
 import { DMMF } from "./types";
 import { parseDocumentationAttributes } from "./helpers";
 import {
@@ -302,6 +302,18 @@ export function getMappedOutputTypeName(
         .replace("AndReturnOutputType", ""),
     );
     return `CreateManyAndReturn${modelTypeName}`;
+  }
+
+  if (
+    outputTypeName.startsWith("UpdateMany") &&
+    outputTypeName.endsWith("AndReturnOutputType")
+  ) {
+    const modelTypeName = dmmfDocument.getModelTypeName(
+      outputTypeName
+        .replace("UpdateMany", "")
+        .replace("AndReturnOutputType", ""),
+    );
+    return `UpdateManyAndReturn${modelTypeName}`;
   }
 
   if (dmmfDocument.isModelName(outputTypeName)) {

--- a/src/generator/dmmf/types.ts
+++ b/src/generator/dmmf/types.ts
@@ -38,6 +38,7 @@ export namespace DMMF {
   export type Model = ReadonlyDeep<{
     name: string;
     dbName: string | null;
+    schema: string | null;
     fields: ModelField[];
     uniqueFields: string[][];
     uniqueIndexes: UniqueIndex[];
@@ -70,12 +71,14 @@ export namespace DMMF {
     isGenerated?: boolean;
     isUpdatedAt?: boolean;
     // type: string;
+    nativeType?: [string, string[]] | null;
     dbNames?: string[] | null;
     hasDefaultValue: boolean;
     default?: FieldDefault | FieldDefaultScalar | FieldDefaultScalar[];
     relationFromFields?: string[];
     relationToFields?: string[];
     relationOnDelete?: string;
+    relationOnUpdate?: string;
     relationName?: string;
     // documentation?: string;
     // [key: string]: any;
@@ -90,7 +93,7 @@ export namespace DMMF {
   }>;
   export type FieldDefault = ReadonlyDeep<{
     name: string;
-    args: any[];
+    args: Array<string | number>;
   }>;
   export type FieldDefaultScalar = string | boolean | number;
   export type Schema = ReadonlyDeep<{
@@ -137,6 +140,7 @@ export namespace DMMF {
     isNullable: boolean;
     isRequired: boolean;
     // inputTypes: InputTypeRef[];
+    requiresOtherFields?: string[];
     deprecation?: Deprecation;
     // additional props:
     selectedInputType: SchemaArgInputType;
@@ -196,6 +200,7 @@ export namespace DMMF {
     };
     meta?: {
       source?: string;
+      grouping?: string;
     };
     fields: SchemaArg[];
     // additional props:
@@ -247,6 +252,7 @@ export namespace DMMF {
     createManyAndReturn = "createManyAndReturn",
     updateOne = "updateOne",
     updateMany = "updateMany",
+    updateManyAndReturn = "updateManyAndReturn",
     upsertOne = "upsertOne",
     deleteOne = "deleteOne",
     deleteMany = "deleteMany",

--- a/src/generator/generate-code.ts
+++ b/src/generator/generate-code.ts
@@ -1,4 +1,4 @@
-import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
+import type * as PrismaDMMF from "@prisma/dmmf";
 import { Project, ScriptTarget, ModuleKind, CompilerOptions } from "ts-morph";
 import path from "path";
 import { exec } from "node:child_process";

--- a/tests/functional/__snapshots__/crud.ts.snap
+++ b/tests/functional/__snapshots__/crud.ts.snap
@@ -226,6 +226,7 @@ exports[`crud resolvers execution basic operations should properly call PrismaCl
 Array [
   Array [
     Object {
+      "limit": 2,
       "where": UserWhereInput {
         "dateField": DateTimeFilter {
           "lte": 2019-12-31T19:16:02.572Z,
@@ -330,6 +331,7 @@ Array [
       "data": UserUpdateManyMutationInput {
         "optionalStringField": null,
       },
+      "limit": 2,
       "where": UserWhereInput {
         "dateField": DateTimeFilter {
           "lte": 2019-12-31T19:16:02.572Z,
@@ -345,6 +347,37 @@ Object {
   "updateManyUser": Object {
     "count": 3,
   },
+}
+`;
+
+exports[`crud resolvers execution basic operations should properly call PrismaClient on \`updateManyAndReturn\` action: updateManyAndReturnUser call args 1`] = `
+Array [
+  Array [
+    Object {
+      "data": UserUpdateManyMutationInput {
+        "optionalStringField": null,
+      },
+      "limit": 2,
+      "where": UserWhereInput {
+        "dateField": DateTimeFilter {
+          "lte": 2019-12-31T19:16:02.572Z,
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`crud resolvers execution basic operations should properly call PrismaClient on \`updateManyAndReturn\` action: updateManyAndReturnUser mocked response 1`] = `
+Object {
+  "updateManyAndReturnUser": Array [
+    Object {
+      "dateField": "2019-12-31T14:16:02.572Z",
+      "intIdField": 1,
+      "optionalStringField": null,
+      "uniqueStringField": "unique",
+    },
+  ],
 }
 `;
 

--- a/tests/functional/__snapshots__/integration.ts.snap
+++ b/tests/functional/__snapshots__/integration.ts.snap
@@ -100,12 +100,14 @@ type Mutation {
   createManyUser(data: [UserCreateManyInput!]!, skipDuplicates: Boolean): AffectedRowsOutput!
   createOnePost(data: PostCreateInput!): Post!
   createOneUser(data: UserCreateInput): User!
-  deleteManyPost(where: PostWhereInput): AffectedRowsOutput!
-  deleteManyUser(where: UserWhereInput): AffectedRowsOutput!
+  deleteManyPost(limit: Int, where: PostWhereInput): AffectedRowsOutput!
+  deleteManyUser(limit: Int, where: UserWhereInput): AffectedRowsOutput!
   deleteOnePost(where: PostWhereUniqueInput!): Post
   deleteOneUser(where: UserWhereUniqueInput!): User
-  updateManyPost(data: PostUpdateManyMutationInput!, where: PostWhereInput): AffectedRowsOutput!
-  updateManyUser(data: UserUpdateManyMutationInput!, where: UserWhereInput): AffectedRowsOutput!
+  updateManyAndReturnPost(data: PostUpdateManyMutationInput!, limit: Int, where: PostWhereInput): [UpdateManyAndReturnPost!]!
+  updateManyAndReturnUser(data: UserUpdateManyMutationInput!, limit: Int, where: UserWhereInput): [UpdateManyAndReturnUser!]!
+  updateManyPost(data: PostUpdateManyMutationInput!, limit: Int, where: PostWhereInput): AffectedRowsOutput!
+  updateManyUser(data: UserUpdateManyMutationInput!, limit: Int, where: UserWhereInput): AffectedRowsOutput!
   updateOnePost(data: PostUpdateInput!, where: PostWhereUniqueInput!): Post
   updateOneUser(data: UserUpdateInput!, where: UserWhereUniqueInput!): User
   upsertOnePost(create: PostCreateInput!, update: PostUpdateInput!, where: PostWhereUniqueInput!): Post!
@@ -481,7 +483,7 @@ input PostWhereInput {
   AND: [PostWhereInput!]
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
-  author: UserRelationFilter
+  author: UserScalarRelationFilter
   authorId: IntFilter
   color: EnumColorFilter
   content: StringFilter
@@ -492,7 +494,7 @@ input PostWhereUniqueInput {
   AND: [PostWhereInput!]
   NOT: [PostWhereInput!]
   OR: [PostWhereInput!]
-  author: UserRelationFilter
+  author: UserScalarRelationFilter
   authorId: IntFilter
   color: EnumColorFilter
   content: StringFilter
@@ -601,6 +603,19 @@ input StringWithAggregatesFilter {
   startsWith: String
 }
 
+type UpdateManyAndReturnPost {
+  author: User!
+  authorId: Int!
+  color: Color!
+  content: String!
+  uuid: String!
+}
+
+type UpdateManyAndReturnUser {
+  id: Int!
+  name: String
+}
+
 type User {
   _count: UserCount
   id: Int!
@@ -702,14 +717,14 @@ input UserOrderByWithRelationInput {
   posts: PostOrderByRelationAggregateInput
 }
 
-input UserRelationFilter {
-  is: UserWhereInput
-  isNot: UserWhereInput
-}
-
 enum UserScalarFieldEnum {
   id
   name
+}
+
+input UserScalarRelationFilter {
+  is: UserWhereInput
+  isNot: UserWhereInput
 }
 
 input UserScalarWhereWithAggregatesInput {
@@ -814,6 +829,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -830,6 +846,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -847,6 +864,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -864,6 +882,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -934,7 +953,7 @@ exports[`generator integration should generates TypeGraphQL classes files to out
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -958,6 +977,8 @@ exports[`generator integration should generates TypeGraphQL classes files to out
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts

--- a/tests/functional/crud.ts
+++ b/tests/functional/crud.ts
@@ -224,6 +224,7 @@ describe("crud resolvers execution", () => {
             where: {
               dateField: { lte: "2019-12-31T19:16:02.572Z" }
             }
+            limit: 2
           ) {
             count
           }
@@ -250,6 +251,51 @@ describe("crud resolvers execution", () => {
       );
     });
 
+    it("should properly call PrismaClient on `updateManyAndReturn` action", async () => {
+      const document = /* graphql */ `
+        mutation {
+          updateManyAndReturnUser(
+            data: {
+              optionalStringField: null,
+            }
+            where: {
+              dateField: { lte: "2019-12-31T19:16:02.572Z" }
+            }
+            limit: 2
+          ) {
+            intIdField
+            uniqueStringField
+            optionalStringField
+            dateField
+          }
+        }
+      `;
+      const prismaMock = {
+        user: {
+          updateManyAndReturn: jest.fn().mockResolvedValue([
+            {
+              intIdField: 1,
+              uniqueStringField: "unique",
+              optionalStringField: null,
+              dateField: new Date("2019-12-31T14:16:02.572Z"),
+            },
+          ]),
+        },
+      };
+
+      const { data, errors } = await graphql({
+        schema: graphQLSchema,
+        source: document,
+        contextValue: { prisma: prismaMock },
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data).toMatchSnapshot("updateManyAndReturnUser mocked response");
+      expect(prismaMock.user.updateManyAndReturn.mock.calls).toMatchSnapshot(
+        "updateManyAndReturnUser call args",
+      );
+    });
+
     it("should properly call PrismaClient on `deleteMany` action", async () => {
       const document = /* graphql */ `
         mutation {
@@ -257,6 +303,7 @@ describe("crud resolvers execution", () => {
             where: {
               dateField: { lte: "2019-12-31T19:16:02.572Z" }
             }
+            limit: 2
           ) {
             count
           }

--- a/tests/functional/integration.ts
+++ b/tests/functional/integration.ts
@@ -16,6 +16,14 @@ describe("generator integration", () => {
   let cwdDirPath: string;
   let schema: string;
 
+  async function assertGeneratedArtifacts(artifactsDirPath: string) {
+    await Promise.all([
+      fs.access(path.join(artifactsDirPath, "generated", "type-graphql", "index.ts")),
+      fs.access(path.join(artifactsDirPath, "generated", "client", "client.ts")),
+      fs.access(path.join(artifactsDirPath, "generated", "client", "models.ts")),
+    ]);
+  }
+
   beforeEach(async () => {
     cwdDirPath = generateArtifactsDirPath("functional-integration");
     await fs.mkdir(cwdDirPath, { recursive: true });
@@ -64,16 +72,14 @@ describe("generator integration", () => {
   });
 
   it("should generates TypeGraphQL classes files to output folder by running `prisma generate`", async () => {
-    const prismaGenerateResult = await exec("npx prisma generate", {
+    await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
-    // console.log(prismaGenerateResult);
 
     const directoryStructureString = getDirectoryStructureString(
       cwdDirPath + "/generated/type-graphql",
     );
 
-    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(directoryStructureString).toMatchSnapshot("files structure");
   }, 60000);
 
@@ -82,18 +88,32 @@ describe("generator integration", () => {
       path.join(cwdDirPath, "schema.prisma"),
       schema.replace('provider = "prisma-client-js"', 'provider = "prisma-client"'),
     );
-    const prismaGenerateResult = await exec("npx prisma generate", {
+    await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
 
-    expect(prismaGenerateResult.stderr).not.toContain("Error:");
+    await assertGeneratedArtifacts(cwdDirPath);
+  }, 60000);
+
+  it("should generate artifacts when using `prisma-client-ts` provider", async () => {
+    await fs.writeFile(
+      path.join(cwdDirPath, "schema.prisma"),
+      schema.replace(
+        'provider = "prisma-client-js"',
+        'provider = "prisma-client-ts"',
+      ),
+    );
+    await exec("npx prisma generate", {
+      cwd: cwdDirPath,
+    });
+
+    await assertGeneratedArtifacts(cwdDirPath);
   }, 60000);
 
   it("should be able to use generate TypeGraphQL classes files to generate GraphQL schema", async () => {
-    const prismaGenerateResult = await exec("npx prisma generate", {
+    await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
-    // console.log(prismaGenerateResult);
     const {
       UserCrudResolver,
       PostCrudResolver,
@@ -114,7 +134,6 @@ describe("generator integration", () => {
       encoding: "utf8",
     });
 
-    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(graphQLSchemaSDL).toMatchSnapshot("graphQLSchemaSDL");
   }, 60000);
 
@@ -138,10 +157,9 @@ describe("generator integration", () => {
       "type-graphql",
     );
 
-    const prismaGenerateResult = await exec("npx prisma generate", {
+    await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
-    // console.log(prismaGenerateResult);
     await fs.writeFile(
       path.join(typegraphqlfolderPath, "tsconfig.json"),
       JSON.stringify(tsconfigContent),
@@ -150,17 +168,14 @@ describe("generator integration", () => {
       cwd: typegraphqlfolderPath,
     });
 
-    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(tscResult.stdout).toHaveLength(0);
     expect(tscResult.stderr).toHaveLength(0);
   }, 60000);
 
   it("should properly fetch the data from DB using PrismaClient while queried by GraphQL schema", async () => {
-    const prismaGenerateResult = await exec("npx prisma generate", {
+    await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
-    // console.log(prismaGenerateResult);
-    expect(prismaGenerateResult.stderr).not.toContain("Error:");
 
     // drop database before migrate
     const originalDatabaseUrl = process.env.TEST_DATABASE_URL!;
@@ -176,12 +191,10 @@ describe("generator integration", () => {
     await pgClient.query(`CREATE DATABASE "${dbName}"`);
     await pgClient.end();
 
-    const prismaMigrateResult = await exec(
+    await exec(
       "npx prisma migrate dev --name init",
       { cwd: cwdDirPath },
     );
-    // console.log(prismaMigrateResult);
-    expect(prismaMigrateResult.stderr).not.toContain("Error:");
 
     const { PrismaClient } = require(cwdDirPath + "/generated/client");
     const prisma = new PrismaClient();

--- a/tests/functional/integration.ts
+++ b/tests/functional/integration.ts
@@ -73,8 +73,20 @@ describe("generator integration", () => {
       cwdDirPath + "/generated/type-graphql",
     );
 
-    expect(prismaGenerateResult.stderr).toHaveLength(0);
+    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(directoryStructureString).toMatchSnapshot("files structure");
+  }, 60000);
+
+  it("should generate artifacts when using `prisma-client` provider", async () => {
+    await fs.writeFile(
+      path.join(cwdDirPath, "schema.prisma"),
+      schema.replace('provider = "prisma-client-js"', 'provider = "prisma-client"'),
+    );
+    const prismaGenerateResult = await exec("npx prisma generate", {
+      cwd: cwdDirPath,
+    });
+
+    expect(prismaGenerateResult.stderr).not.toContain("Error:");
   }, 60000);
 
   it("should be able to use generate TypeGraphQL classes files to generate GraphQL schema", async () => {
@@ -102,7 +114,7 @@ describe("generator integration", () => {
       encoding: "utf8",
     });
 
-    expect(prismaGenerateResult.stderr).toHaveLength(0);
+    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(graphQLSchemaSDL).toMatchSnapshot("graphQLSchemaSDL");
   }, 60000);
 
@@ -138,7 +150,7 @@ describe("generator integration", () => {
       cwd: typegraphqlfolderPath,
     });
 
-    expect(prismaGenerateResult.stderr).toHaveLength(0);
+    expect(prismaGenerateResult.stderr).not.toContain("Error:");
     expect(tscResult.stdout).toHaveLength(0);
     expect(tscResult.stderr).toHaveLength(0);
   }, 60000);
@@ -148,7 +160,7 @@ describe("generator integration", () => {
       cwd: cwdDirPath,
     });
     // console.log(prismaGenerateResult);
-    expect(prismaGenerateResult.stderr).toHaveLength(0);
+    expect(prismaGenerateResult.stderr).not.toContain("Error:");
 
     // drop database before migrate
     const originalDatabaseUrl = process.env.TEST_DATABASE_URL!;
@@ -161,14 +173,15 @@ describe("generator integration", () => {
     });
     await pgClient.connect();
     await pgClient.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    await pgClient.query(`CREATE DATABASE "${dbName}"`);
     await pgClient.end();
 
     const prismaMigrateResult = await exec(
-      "npx prisma migrate dev --preview-feature --name init",
+      "npx prisma migrate dev --name init",
       { cwd: cwdDirPath },
     );
     // console.log(prismaMigrateResult);
-    expect(prismaMigrateResult.stderr).toHaveLength(0);
+    expect(prismaMigrateResult.stderr).not.toContain("Error:");
 
     const { PrismaClient } = require(cwdDirPath + "/generated/client");
     const prisma = new PrismaClient();

--- a/tests/functional/integration.ts
+++ b/tests/functional/integration.ts
@@ -12,15 +12,35 @@ import { getDirectoryStructureString } from "../helpers/structure";
 
 const exec = util.promisify(childProcess.exec);
 
+function normalizePrismaStderr(stderr: string) {
+  return stderr
+    .split(/\r?\n/)
+    .filter(
+      line => !line.trim().startsWith("Environment variables loaded from"),
+    )
+    .join("\n")
+    .trim();
+}
+
+function expectNoPrismaStderr(stderr: string) {
+  expect(normalizePrismaStderr(stderr)).toHaveLength(0);
+}
+
 describe("generator integration", () => {
   let cwdDirPath: string;
   let schema: string;
 
   async function assertGeneratedArtifacts(artifactsDirPath: string) {
     await Promise.all([
-      fs.access(path.join(artifactsDirPath, "generated", "type-graphql", "index.ts")),
-      fs.access(path.join(artifactsDirPath, "generated", "client", "client.ts")),
-      fs.access(path.join(artifactsDirPath, "generated", "client", "models.ts")),
+      fs.access(
+        path.join(artifactsDirPath, "generated", "type-graphql", "index.ts"),
+      ),
+      fs.access(
+        path.join(artifactsDirPath, "generated", "client", "client.ts"),
+      ),
+      fs.access(
+        path.join(artifactsDirPath, "generated", "client", "models.ts"),
+      ),
     ]);
   }
 
@@ -72,9 +92,10 @@ describe("generator integration", () => {
   });
 
   it("should generates TypeGraphQL classes files to output folder by running `prisma generate`", async () => {
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
 
     const directoryStructureString = getDirectoryStructureString(
       cwdDirPath + "/generated/type-graphql",
@@ -86,11 +107,15 @@ describe("generator integration", () => {
   it("should generate artifacts when using `prisma-client` provider", async () => {
     await fs.writeFile(
       path.join(cwdDirPath, "schema.prisma"),
-      schema.replace('provider = "prisma-client-js"', 'provider = "prisma-client"'),
+      schema.replace(
+        'provider = "prisma-client-js"',
+        'provider = "prisma-client"',
+      ),
     );
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
 
     await assertGeneratedArtifacts(cwdDirPath);
   }, 60000);
@@ -103,17 +128,19 @@ describe("generator integration", () => {
         'provider = "prisma-client-ts"',
       ),
     );
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
 
     await assertGeneratedArtifacts(cwdDirPath);
   }, 60000);
 
   it("should be able to use generate TypeGraphQL classes files to generate GraphQL schema", async () => {
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
     const {
       UserCrudResolver,
       PostCrudResolver,
@@ -157,9 +184,10 @@ describe("generator integration", () => {
       "type-graphql",
     );
 
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
     await fs.writeFile(
       path.join(typegraphqlfolderPath, "tsconfig.json"),
       JSON.stringify(tsconfigContent),
@@ -173,9 +201,10 @@ describe("generator integration", () => {
   }, 60000);
 
   it("should properly fetch the data from DB using PrismaClient while queried by GraphQL schema", async () => {
-    await exec("npx prisma generate", {
+    const prismaGenerateResult = await exec("npx prisma generate", {
       cwd: cwdDirPath,
     });
+    expectNoPrismaStderr(prismaGenerateResult.stderr);
 
     // drop database before migrate
     const originalDatabaseUrl = process.env.TEST_DATABASE_URL!;
@@ -191,10 +220,11 @@ describe("generator integration", () => {
     await pgClient.query(`CREATE DATABASE "${dbName}"`);
     await pgClient.end();
 
-    await exec(
+    const prismaMigrateResult = await exec(
       "npx prisma migrate dev --name init",
       { cwd: cwdDirPath },
     );
+    expectNoPrismaStderr(prismaMigrateResult.stderr);
 
     const { PrismaClient } = require(cwdDirPath + "/generated/client");
     const prisma = new PrismaClient();

--- a/tests/helpers/dmmf.ts
+++ b/tests/helpers/dmmf.ts
@@ -1,4 +1,4 @@
-import type { DMMF as PrismaDMMF } from "@prisma/generator-helper";
+import type * as PrismaDMMF from "@prisma/dmmf";
 import { getDMMF } from "@prisma/internals";
 
 export default async function getPrismaClientDmmfFromPrismaSchema(

--- a/tests/regression/__snapshots__/crud.ts.snap
+++ b/tests/regression/__snapshots__/crud.ts.snap
@@ -350,6 +350,7 @@ export { FindUniqueUserResolver } from \\"./User/FindUniqueUserResolver\\";
 export { FindUniqueUserOrThrowResolver } from \\"./User/FindUniqueUserOrThrowResolver\\";
 export { GroupByUserResolver } from \\"./User/GroupByUserResolver\\";
 export { UpdateManyUserResolver } from \\"./User/UpdateManyUserResolver\\";
+export { UpdateManyAndReturnUserResolver } from \\"./User/UpdateManyAndReturnUserResolver\\";
 export { UpdateOneUserResolver } from \\"./User/UpdateOneUserResolver\\";
 export { UpsertOneUserResolver } from \\"./User/UpsertOneUserResolver\\";
 "
@@ -468,6 +469,11 @@ export class DeleteManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -702,6 +708,7 @@ export { FindManyUserArgs } from \\"./FindManyUserArgs\\";
 export { FindUniqueUserArgs } from \\"./FindUniqueUserArgs\\";
 export { FindUniqueUserOrThrowArgs } from \\"./FindUniqueUserOrThrowArgs\\";
 export { GroupByUserArgs } from \\"./GroupByUserArgs\\";
+export { UpdateManyAndReturnUserArgs } from \\"./UpdateManyAndReturnUserArgs\\";
 export { UpdateManyUserArgs } from \\"./UpdateManyUserArgs\\";
 export { UpdateOneUserArgs } from \\"./UpdateOneUserArgs\\";
 export { UpsertOneUserArgs } from \\"./UpsertOneUserArgs\\";
@@ -725,6 +732,11 @@ export class UpdateManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -956,6 +968,7 @@ export { FindManyFirstModelArgs } from \\"./FindManyFirstModelArgs\\";
 export { FindUniqueFirstModelArgs } from \\"./FindUniqueFirstModelArgs\\";
 export { FindUniqueFirstModelOrThrowArgs } from \\"./FindUniqueFirstModelOrThrowArgs\\";
 export { GroupByFirstModelArgs } from \\"./GroupByFirstModelArgs\\";
+export { UpdateManyAndReturnFirstModelArgs } from \\"./UpdateManyAndReturnFirstModelArgs\\";
 export { UpdateManyFirstModelArgs } from \\"./UpdateManyFirstModelArgs\\";
 export { UpdateOneFirstModelArgs } from \\"./UpdateOneFirstModelArgs\\";
 export { UpsertOneFirstModelArgs } from \\"./UpsertOneFirstModelArgs\\";
@@ -1098,6 +1111,7 @@ export { FindManySecondModelArgs } from \\"./FindManySecondModelArgs\\";
 export { FindUniqueSecondModelArgs } from \\"./FindUniqueSecondModelArgs\\";
 export { FindUniqueSecondModelOrThrowArgs } from \\"./FindUniqueSecondModelOrThrowArgs\\";
 export { GroupBySecondModelArgs } from \\"./GroupBySecondModelArgs\\";
+export { UpdateManyAndReturnSecondModelArgs } from \\"./UpdateManyAndReturnSecondModelArgs\\";
 export { UpdateManySecondModelArgs } from \\"./UpdateManySecondModelArgs\\";
 export { UpdateOneSecondModelArgs } from \\"./UpdateOneSecondModelArgs\\";
 export { UpsertOneSecondModelArgs } from \\"./UpsertOneSecondModelArgs\\";
@@ -1126,6 +1140,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -1134,6 +1149,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -1282,6 +1298,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -1321,6 +1348,7 @@ export { FindUniqueUserResolver } from \\"./User/FindUniqueUserResolver\\";
 export { FindUniqueUserOrThrowResolver } from \\"./User/FindUniqueUserOrThrowResolver\\";
 export { GroupByUserResolver } from \\"./User/GroupByUserResolver\\";
 export { UpdateManyUserResolver } from \\"./User/UpdateManyUserResolver\\";
+export { UpdateManyAndReturnUserResolver } from \\"./User/UpdateManyAndReturnUserResolver\\";
 export { UpdateOneUserResolver } from \\"./User/UpdateOneUserResolver\\";
 export { UpsertOneUserResolver } from \\"./User/UpsertOneUserResolver\\";
 "
@@ -1373,6 +1401,7 @@ import { FindManyStaffArgs } from \\"./args/FindManyStaffArgs\\";
 import { FindUniqueStaffArgs } from \\"./args/FindUniqueStaffArgs\\";
 import { FindUniqueStaffOrThrowArgs } from \\"./args/FindUniqueStaffOrThrowArgs\\";
 import { GroupByStaffArgs } from \\"./args/GroupByStaffArgs\\";
+import { UpdateManyAndReturnStaffArgs } from \\"./args/UpdateManyAndReturnStaffArgs\\";
 import { UpdateManyStaffArgs } from \\"./args/UpdateManyStaffArgs\\";
 import { UpdateOneStaffArgs } from \\"./args/UpdateOneStaffArgs\\";
 import { UpsertOneStaffArgs } from \\"./args/UpsertOneStaffArgs\\";
@@ -1382,6 +1411,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateStaff } from \\"../../outputs/AggregateStaff\\";
 import { CreateManyAndReturnStaff } from \\"../../outputs/CreateManyAndReturnStaff\\";
 import { StaffGroupBy } from \\"../../outputs/StaffGroupBy\\";
+import { UpdateManyAndReturnStaff } from \\"../../outputs/UpdateManyAndReturnStaff\\";
 
 @TypeGraphQL.Resolver(_of => Staff)
 export class StaffCrudResolver {
@@ -1529,6 +1559,17 @@ export class StaffCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnStaff], {
+    nullable: false
+  })
+  async updateManyAndReturnStaff(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnStaffArgs): Promise<UpdateManyAndReturnStaff[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).staff.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Staff, {
     nullable: true
   })
@@ -1569,6 +1610,7 @@ import { FindManyStaffArgs } from \\"./args/FindManyStaffArgs\\";
 import { FindUniqueStaffArgs } from \\"./args/FindUniqueStaffArgs\\";
 import { FindUniqueStaffOrThrowArgs } from \\"./args/FindUniqueStaffOrThrowArgs\\";
 import { GroupByStaffArgs } from \\"./args/GroupByStaffArgs\\";
+import { UpdateManyAndReturnStaffArgs } from \\"./args/UpdateManyAndReturnStaffArgs\\";
 import { UpdateManyStaffArgs } from \\"./args/UpdateManyStaffArgs\\";
 import { UpdateOneStaffArgs } from \\"./args/UpdateOneStaffArgs\\";
 import { UpsertOneStaffArgs } from \\"./args/UpsertOneStaffArgs\\";
@@ -1578,6 +1620,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateStaff } from \\"../../outputs/AggregateStaff\\";
 import { CreateManyAndReturnStaff } from \\"../../outputs/CreateManyAndReturnStaff\\";
 import { StaffGroupBy } from \\"../../outputs/StaffGroupBy\\";
+import { UpdateManyAndReturnStaff } from \\"../../outputs/UpdateManyAndReturnStaff\\";
 
 @TypeGraphQL.Resolver(_of => Staff)
 export class StaffCrudResolver {
@@ -1725,6 +1768,17 @@ export class StaffCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnStaff], {
+    nullable: false
+  })
+  async updateManyAndReturnStaff(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnStaffArgs): Promise<UpdateManyAndReturnStaff[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).staff.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Staff, {
     nullable: true
   })
@@ -1811,6 +1865,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -1819,6 +1874,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -1967,6 +2023,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -2007,6 +2074,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2015,6 +2083,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2163,6 +2232,17 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false
+  })
+  async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args(_type => UpdateManyAndReturnUserArgs) args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true
   })
@@ -2206,6 +2286,7 @@ const FindManyUserArgs_1 = require(\\"./args/FindManyUserArgs\\");
 const FindUniqueUserArgs_1 = require(\\"./args/FindUniqueUserArgs\\");
 const FindUniqueUserOrThrowArgs_1 = require(\\"./args/FindUniqueUserOrThrowArgs\\");
 const GroupByUserArgs_1 = require(\\"./args/GroupByUserArgs\\");
+const UpdateManyAndReturnUserArgs_1 = require(\\"./args/UpdateManyAndReturnUserArgs\\");
 const UpdateManyUserArgs_1 = require(\\"./args/UpdateManyUserArgs\\");
 const UpdateOneUserArgs_1 = require(\\"./args/UpdateOneUserArgs\\");
 const UpsertOneUserArgs_1 = require(\\"./args/UpsertOneUserArgs\\");
@@ -2214,6 +2295,7 @@ const User_1 = require(\\"../../../models/User\\");
 const AffectedRowsOutput_1 = require(\\"../../outputs/AffectedRowsOutput\\");
 const AggregateUser_1 = require(\\"../../outputs/AggregateUser\\");
 const CreateManyAndReturnUser_1 = require(\\"../../outputs/CreateManyAndReturnUser\\");
+const UpdateManyAndReturnUser_1 = require(\\"../../outputs/UpdateManyAndReturnUser\\");
 const UserGroupBy_1 = require(\\"../../outputs/UserGroupBy\\");
 let UserCrudResolver = class UserCrudResolver {
     async aggregateUser(ctx, info, args) {
@@ -2302,6 +2384,13 @@ let UserCrudResolver = class UserCrudResolver {
     async updateManyUser(ctx, info, args) {
         const { _count } = (0, helpers_1.transformInfoIntoPrismaArgs)(info);
         return (0, helpers_1.getPrismaFromContext)(ctx).user.updateMany({
+            ...args,
+            ...(_count && (0, helpers_1.transformCountFieldIntoSelectRelationsCount)(_count)),
+        });
+    }
+    async updateManyAndReturnUser(ctx, info, args) {
+        const { _count } = (0, helpers_1.transformInfoIntoPrismaArgs)(info);
+        return (0, helpers_1.getPrismaFromContext)(ctx).user.updateManyAndReturn({
             ...args,
             ...(_count && (0, helpers_1.transformCountFieldIntoSelectRelationsCount)(_count)),
         });
@@ -2466,6 +2555,17 @@ tslib_1.__decorate([
     tslib_1.__metadata(\\"design:returntype\\", Promise)
 ], UserCrudResolver.prototype, \\"updateManyUser\\", null);
 tslib_1.__decorate([
+    TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser_1.UpdateManyAndReturnUser], {
+        nullable: false
+    }),
+    tslib_1.__param(0, TypeGraphQL.Ctx()),
+    tslib_1.__param(1, TypeGraphQL.Info()),
+    tslib_1.__param(2, TypeGraphQL.Args()),
+    tslib_1.__metadata(\\"design:type\\", Function),
+    tslib_1.__metadata(\\"design:paramtypes\\", [Object, Object, UpdateManyAndReturnUserArgs_1.UpdateManyAndReturnUserArgs]),
+    tslib_1.__metadata(\\"design:returntype\\", Promise)
+], UserCrudResolver.prototype, \\"updateManyAndReturnUser\\", null);
+tslib_1.__decorate([
     TypeGraphQL.Mutation(_returns => User_1.User, {
         nullable: true
     }),
@@ -2508,6 +2608,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2520,6 +2621,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2723,6 +2825,21 @@ export class UserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+    nullable: false,
+  })
+  async updateManyAndReturnUser(
+    @TypeGraphQL.Ctx() ctx: any,
+    @TypeGraphQL.Info() info: GraphQLResolveInfo,
+    @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs,
+  ): Promise<UpdateManyAndReturnUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => User, {
     nullable: true,
   })
@@ -2771,6 +2888,7 @@ import { FindManyUserArgs } from \\"./args/FindManyUserArgs\\";
 import { FindUniqueUserArgs } from \\"./args/FindUniqueUserArgs\\";
 import { FindUniqueUserOrThrowArgs } from \\"./args/FindUniqueUserOrThrowArgs\\";
 import { GroupByUserArgs } from \\"./args/GroupByUserArgs\\";
+import { UpdateManyAndReturnUserArgs } from \\"./args/UpdateManyAndReturnUserArgs\\";
 import { UpdateManyUserArgs } from \\"./args/UpdateManyUserArgs\\";
 import { UpdateOneUserArgs } from \\"./args/UpdateOneUserArgs\\";
 import { UpsertOneUserArgs } from \\"./args/UpsertOneUserArgs\\";
@@ -2779,6 +2897,7 @@ import { User } from \\"../../../models/User\\";
 import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateUser } from \\"../../outputs/AggregateUser\\";
 import { CreateManyAndReturnUser } from \\"../../outputs/CreateManyAndReturnUser\\";
+import { UpdateManyAndReturnUser } from \\"../../outputs/UpdateManyAndReturnUser\\";
 import { UserGroupBy } from \\"../../outputs/UserGroupBy\\";
 
 @TypeGraphQL.Resolver(_of => User)
@@ -2922,6 +3041,17 @@ export class UserCrudResolver {
     async updateManyUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyUserArgs): Promise<AffectedRowsOutput> {
          const { _count } = transformInfoIntoPrismaArgs(info);
                     return getPrismaFromContext(ctx).user.updateMany({
+                      ...args,
+                      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+                    });
+    }
+
+    @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnUser], {
+            nullable: false
+        })
+    async updateManyAndReturnUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnUserArgs): Promise<UpdateManyAndReturnUser[]> {
+         const { _count } = transformInfoIntoPrismaArgs(info);
+                    return getPrismaFromContext(ctx).user.updateManyAndReturn({
                       ...args,
                       ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
                     });
@@ -3376,6 +3506,11 @@ export class DeleteManyClientArgs {
     nullable: true
   })
   where?: ClientWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -3537,6 +3672,7 @@ export { FindManyClientArgs } from \\"./FindManyClientArgs\\";
 export { FindUniqueClientArgs } from \\"./FindUniqueClientArgs\\";
 export { FindUniqueClientOrThrowArgs } from \\"./FindUniqueClientOrThrowArgs\\";
 export { GroupByClientArgs } from \\"./GroupByClientArgs\\";
+export { UpdateManyAndReturnClientArgs } from \\"./UpdateManyAndReturnClientArgs\\";
 export { UpdateManyClientArgs } from \\"./UpdateManyClientArgs\\";
 export { UpdateOneClientArgs } from \\"./UpdateOneClientArgs\\";
 export { UpsertOneClientArgs } from \\"./UpsertOneClientArgs\\";
@@ -3581,6 +3717,11 @@ export class UpdateManyClientArgs {
     nullable: true
   })
   where?: ClientWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;
@@ -3650,6 +3791,7 @@ import { FindManyClientArgs } from \\"./args/FindManyClientArgs\\";
 import { FindUniqueClientArgs } from \\"./args/FindUniqueClientArgs\\";
 import { FindUniqueClientOrThrowArgs } from \\"./args/FindUniqueClientOrThrowArgs\\";
 import { GroupByClientArgs } from \\"./args/GroupByClientArgs\\";
+import { UpdateManyAndReturnClientArgs } from \\"./args/UpdateManyAndReturnClientArgs\\";
 import { UpdateManyClientArgs } from \\"./args/UpdateManyClientArgs\\";
 import { UpdateOneClientArgs } from \\"./args/UpdateOneClientArgs\\";
 import { UpsertOneClientArgs } from \\"./args/UpsertOneClientArgs\\";
@@ -3659,6 +3801,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateClient } from \\"../../outputs/AggregateClient\\";
 import { ClientGroupBy } from \\"../../outputs/ClientGroupBy\\";
 import { CreateManyAndReturnClient } from \\"../../outputs/CreateManyAndReturnClient\\";
+import { UpdateManyAndReturnClient } from \\"../../outputs/UpdateManyAndReturnClient\\";
 
 @TypeGraphQL.Resolver(_of => Client)
 export class ClientCrudResolver {
@@ -3806,6 +3949,17 @@ export class ClientCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnClient], {
+    nullable: false
+  })
+  async updateManyAndReturnClient(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnClientArgs): Promise<UpdateManyAndReturnClient[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => Client, {
     nullable: true
   })
@@ -3872,6 +4026,7 @@ import { FindManyMainUserArgs } from \\"./args/FindManyMainUserArgs\\";
 import { FindUniqueMainUserArgs } from \\"./args/FindUniqueMainUserArgs\\";
 import { FindUniqueMainUserOrThrowArgs } from \\"./args/FindUniqueMainUserOrThrowArgs\\";
 import { GroupByMainUserArgs } from \\"./args/GroupByMainUserArgs\\";
+import { UpdateManyAndReturnMainUserArgs } from \\"./args/UpdateManyAndReturnMainUserArgs\\";
 import { UpdateManyMainUserArgs } from \\"./args/UpdateManyMainUserArgs\\";
 import { UpdateOneMainUserArgs } from \\"./args/UpdateOneMainUserArgs\\";
 import { UpsertOneMainUserArgs } from \\"./args/UpsertOneMainUserArgs\\";
@@ -3881,6 +4036,7 @@ import { AffectedRowsOutput } from \\"../../outputs/AffectedRowsOutput\\";
 import { AggregateMainUser } from \\"../../outputs/AggregateMainUser\\";
 import { CreateManyAndReturnMainUser } from \\"../../outputs/CreateManyAndReturnMainUser\\";
 import { MainUserGroupBy } from \\"../../outputs/MainUserGroupBy\\";
+import { UpdateManyAndReturnMainUser } from \\"../../outputs/UpdateManyAndReturnMainUser\\";
 
 @TypeGraphQL.Resolver(_of => MainUser)
 export class MainUserCrudResolver {
@@ -4028,6 +4184,17 @@ export class MainUserCrudResolver {
     });
   }
 
+  @TypeGraphQL.Mutation(_returns => [UpdateManyAndReturnMainUser], {
+    nullable: false
+  })
+  async updateManyAndReturnMainUser(@TypeGraphQL.Ctx() ctx: any, @TypeGraphQL.Info() info: GraphQLResolveInfo, @TypeGraphQL.Args() args: UpdateManyAndReturnMainUserArgs): Promise<UpdateManyAndReturnMainUser[]> {
+    const { _count } = transformInfoIntoPrismaArgs(info);
+    return getPrismaFromContext(ctx).user.updateManyAndReturn({
+      ...args,
+      ...(_count && transformCountFieldIntoSelectRelationsCount(_count)),
+    });
+  }
+
   @TypeGraphQL.Mutation(_returns => MainUser, {
     nullable: true
   })
@@ -4085,6 +4252,11 @@ export class UpdateManyUserArgs {
     nullable: true
   })
   where?: UserWhereInput | undefined;
+
+  @TypeGraphQL.Field(_type => TypeGraphQL.Int, {
+    nullable: true
+  })
+  limit?: number | undefined;
 }
 "
 `;

--- a/tests/regression/__snapshots__/emit-only.ts.snap
+++ b/tests/regression/__snapshots__/emit-only.ts.snap
@@ -31,6 +31,7 @@ const actionResolversMap = {
     getUser: actionResolvers.FindUniqueUserOrThrowResolver,
     groupByUser: actionResolvers.GroupByUserResolver,
     updateManyUser: actionResolvers.UpdateManyUserResolver,
+    updateManyAndReturnUser: actionResolvers.UpdateManyAndReturnUserResolver,
     updateOneUser: actionResolvers.UpdateOneUserResolver,
     upsertOneUser: actionResolvers.UpsertOneUserResolver
   },
@@ -48,20 +49,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateManyAndReturnUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneUserArgs: [\\"data\\"],
-  DeleteManyUserArgs: [\\"where\\"],
+  DeleteManyUserArgs: [\\"where\\", \\"limit\\"],
   DeleteOneUserArgs: [\\"where\\"],
   FindFirstUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstUserOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -69,14 +71,15 @@ const argsInfo = {
   FindUniqueUserArgs: [\\"where\\"],
   FindUniqueUserOrThrowArgs: [\\"where\\"],
   GroupByUserArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyUserArgs: [\\"data\\", \\"where\\"],
+  UpdateManyUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneUserArgs: [\\"data\\", \\"where\\"],
   UpsertOneUserArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -84,7 +87,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -112,7 +116,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -281,7 +285,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -354,8 +360,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -365,7 +371,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -387,7 +393,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -502,6 +508,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -518,6 +525,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -535,6 +543,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -552,6 +561,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -630,7 +640,7 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -654,6 +664,8 @@ exports[`emitOnly generator option when both 'crudResolvers' and \`inputs\` is s
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -700,6 +712,7 @@ const actionResolversMap = {
     getUser: actionResolvers.FindUniqueUserOrThrowResolver,
     groupByUser: actionResolvers.GroupByUserResolver,
     updateManyUser: actionResolvers.UpdateManyUserResolver,
+    updateManyAndReturnUser: actionResolvers.UpdateManyAndReturnUserResolver,
     updateOneUser: actionResolvers.UpdateOneUserResolver,
     upsertOneUser: actionResolvers.UpsertOneUserResolver
   },
@@ -717,20 +730,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  User: [\\"aggregateUser\\", \\"createManyUser\\", \\"createManyAndReturnUser\\", \\"createOneUser\\", \\"deleteManyUser\\", \\"deleteOneUser\\", \\"findFirstUser\\", \\"findFirstUserOrThrow\\", \\"users\\", \\"user\\", \\"getUser\\", \\"groupByUser\\", \\"updateManyUser\\", \\"updateManyAndReturnUser\\", \\"updateOneUser\\", \\"upsertOneUser\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnUserArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneUserArgs: [\\"data\\"],
-  DeleteManyUserArgs: [\\"where\\"],
+  DeleteManyUserArgs: [\\"where\\", \\"limit\\"],
   DeleteOneUserArgs: [\\"where\\"],
   FindFirstUserArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstUserOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -738,14 +752,15 @@ const argsInfo = {
   FindUniqueUserArgs: [\\"where\\"],
   FindUniqueUserOrThrowArgs: [\\"where\\"],
   GroupByUserArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyUserArgs: [\\"data\\", \\"where\\"],
+  UpdateManyUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnUserArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneUserArgs: [\\"data\\", \\"where\\"],
   UpsertOneUserArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -753,7 +768,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -781,7 +797,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -950,7 +966,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -1023,8 +1041,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -1034,7 +1052,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -1056,7 +1074,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -1171,6 +1189,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
         FindUniquePostResolver.ts
         GroupByPostResolver.ts
         PostCrudResolver.ts
+        UpdateManyAndReturnPostResolver.ts
         UpdateManyPostResolver.ts
         UpdateOnePostResolver.ts
         UpsertOnePostResolver.ts
@@ -1187,6 +1206,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
           FindUniquePostArgs.ts
           FindUniquePostOrThrowArgs.ts
           GroupByPostArgs.ts
+          UpdateManyAndReturnPostArgs.ts
           UpdateManyPostArgs.ts
           UpdateOnePostArgs.ts
           UpsertOnePostArgs.ts
@@ -1204,6 +1224,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
         FindUniqueUserOrThrowResolver.ts
         FindUniqueUserResolver.ts
         GroupByUserResolver.ts
+        UpdateManyAndReturnUserResolver.ts
         UpdateManyUserResolver.ts
         UpdateOneUserResolver.ts
         UpsertOneUserResolver.ts
@@ -1221,6 +1242,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
           FindUniqueUserArgs.ts
           FindUniqueUserOrThrowArgs.ts
           GroupByUserArgs.ts
+          UpdateManyAndReturnUserArgs.ts
           UpdateManyUserArgs.ts
           UpdateOneUserArgs.ts
           UpsertOneUserArgs.ts
@@ -1299,7 +1321,7 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -1323,6 +1345,8 @@ exports[`emitOnly generator option when only 'crudResolvers' is set should gener
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -1451,8 +1475,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -1462,7 +1486,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -1484,7 +1508,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -1638,7 +1662,7 @@ exports[`emitOnly generator option when only 'inputs' is set should generate pro
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts
@@ -1863,7 +1887,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnUser: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnUser: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -1945,6 +1971,8 @@ exports[`emitOnly generator option when only 'outputs' is set should generate pr
       PostMaxAggregate.ts
       PostMinAggregate.ts
       PostSumAggregate.ts
+      UpdateManyAndReturnPost.ts
+      UpdateManyAndReturnUser.ts
       UserAvgAggregate.ts
       UserCount.ts
       UserCountAggregate.ts
@@ -2129,8 +2157,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  UserRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -2140,7 +2168,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -2162,7 +2190,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -2331,7 +2359,7 @@ exports[`emitOnly generator option when only 'relationResolvers' is set should g
       UserMinOrderByAggregateInput.ts
       UserOrderByWithAggregationInput.ts
       UserOrderByWithRelationInput.ts
-      UserRelationFilter.ts
+      UserScalarRelationFilter.ts
       UserScalarWhereWithAggregatesInput.ts
       UserSumOrderByAggregateInput.ts
       UserUpdateInput.ts

--- a/tests/regression/__snapshots__/enhance.ts.snap
+++ b/tests/regression/__snapshots__/enhance.ts.snap
@@ -32,6 +32,7 @@ const actionResolversMap = {
     getClient: actionResolvers.FindUniqueClientOrThrowResolver,
     groupByClient: actionResolvers.GroupByClientResolver,
     updateManyClient: actionResolvers.UpdateManyClientResolver,
+    updateManyAndReturnClient: actionResolvers.UpdateManyAndReturnClientResolver,
     updateOneClient: actionResolvers.UpdateOneClientResolver,
     upsertOneClient: actionResolvers.UpsertOneClientResolver
   },
@@ -49,20 +50,21 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  Client: [\\"aggregateClient\\", \\"createManyClient\\", \\"createManyAndReturnClient\\", \\"createOneClient\\", \\"deleteManyClient\\", \\"deleteOneClient\\", \\"findFirstClient\\", \\"findFirstClientOrThrow\\", \\"clients\\", \\"client\\", \\"getClient\\", \\"groupByClient\\", \\"updateManyClient\\", \\"updateOneClient\\", \\"upsertOneClient\\"],
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  Client: [\\"aggregateClient\\", \\"createManyClient\\", \\"createManyAndReturnClient\\", \\"createOneClient\\", \\"deleteManyClient\\", \\"deleteOneClient\\", \\"findFirstClient\\", \\"findFirstClientOrThrow\\", \\"clients\\", \\"client\\", \\"getClient\\", \\"groupByClient\\", \\"updateManyClient\\", \\"updateManyAndReturnClient\\", \\"updateOneClient\\", \\"upsertOneClient\\"],
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregateClientArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyClientArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnClientArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOneClientArgs: [\\"data\\"],
-  DeleteManyClientArgs: [\\"where\\"],
+  DeleteManyClientArgs: [\\"where\\", \\"limit\\"],
   DeleteOneClientArgs: [\\"where\\"],
   FindFirstClientArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstClientOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -70,14 +72,15 @@ const argsInfo = {
   FindUniqueClientArgs: [\\"where\\"],
   FindUniqueClientOrThrowArgs: [\\"where\\"],
   GroupByClientArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyClientArgs: [\\"data\\", \\"where\\"],
+  UpdateManyClientArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnClientArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOneClientArgs: [\\"data\\", \\"where\\"],
   UpsertOneClientArgs: [\\"where\\", \\"create\\", \\"update\\"],
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -85,7 +88,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -113,7 +117,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -329,7 +333,9 @@ const outputsInfo = {
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\"],
   CreateManyAndReturnClient: [\\"id\\", \\"email\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
+  UpdateManyAndReturnClient: [\\"id\\", \\"email\\"],
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\", \\"author\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -402,8 +408,8 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  ClientRelationFilter: [\\"is\\", \\"isNot\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  UserScalarRelationFilter: [\\"is\\", \\"isNot\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"authorId\\", \\"metadata\\"],
   PostAvgOrderByAggregateInput: [\\"authorId\\"],
@@ -413,7 +419,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   PostCreateNestedManyWithoutAuthorInput: [\\"create\\", \\"connectOrCreate\\", \\"createMany\\", \\"connect\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   PostUpdateManyWithoutAuthorNestedInput: [\\"create\\", \\"connectOrCreate\\", \\"upsert\\", \\"createMany\\", \\"set\\", \\"disconnect\\", \\"delete\\", \\"connect\\", \\"update\\", \\"updateMany\\", \\"deleteMany\\"],
@@ -435,7 +441,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   PostCreateWithoutAuthorInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostCreateOrConnectWithoutAuthorInput: [\\"where\\", \\"create\\"],
   PostCreateManyAuthorInputEnvelope: [\\"data\\", \\"skipDuplicates\\"],
@@ -549,19 +555,20 @@ const actionResolversMap = {
     getPost: actionResolvers.FindUniquePostOrThrowResolver,
     groupByPost: actionResolvers.GroupByPostResolver,
     updateManyPost: actionResolvers.UpdateManyPostResolver,
+    updateManyAndReturnPost: actionResolvers.UpdateManyAndReturnPostResolver,
     updateOnePost: actionResolvers.UpdateOnePostResolver,
     upsertOnePost: actionResolvers.UpsertOnePostResolver
   }
 };
 const crudResolversInfo = {
-  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
+  Post: [\\"aggregatePost\\", \\"createManyPost\\", \\"createManyAndReturnPost\\", \\"createOnePost\\", \\"deleteManyPost\\", \\"deleteOnePost\\", \\"findFirstPost\\", \\"findFirstPostOrThrow\\", \\"posts\\", \\"post\\", \\"getPost\\", \\"groupByPost\\", \\"updateManyPost\\", \\"updateManyAndReturnPost\\", \\"updateOnePost\\", \\"upsertOnePost\\"]
 };
 const argsInfo = {
   AggregatePostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\"],
   CreateManyPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateManyAndReturnPostArgs: [\\"data\\", \\"skipDuplicates\\"],
   CreateOnePostArgs: [\\"data\\"],
-  DeleteManyPostArgs: [\\"where\\"],
+  DeleteManyPostArgs: [\\"where\\", \\"limit\\"],
   DeleteOnePostArgs: [\\"where\\"],
   FindFirstPostArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
   FindFirstPostOrThrowArgs: [\\"where\\", \\"orderBy\\", \\"cursor\\", \\"take\\", \\"skip\\", \\"distinct\\"],
@@ -569,7 +576,8 @@ const argsInfo = {
   FindUniquePostArgs: [\\"where\\"],
   FindUniquePostOrThrowArgs: [\\"where\\"],
   GroupByPostArgs: [\\"where\\", \\"orderBy\\", \\"by\\", \\"having\\", \\"take\\", \\"skip\\"],
-  UpdateManyPostArgs: [\\"data\\", \\"where\\"],
+  UpdateManyPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
+  UpdateManyAndReturnPostArgs: [\\"data\\", \\"where\\", \\"limit\\"],
   UpdateOnePostArgs: [\\"data\\", \\"where\\"],
   UpsertOnePostArgs: [\\"where\\", \\"create\\", \\"update\\"]
 };
@@ -597,7 +605,7 @@ export function applyResolversEnhanceMap(
   resolversEnhanceMap: ResolversEnhanceMap,
 ) {
   const mutationOperationPrefixes = [
-    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"upsertOne\\"
+    \\"createOne\\", \\"createMany\\", \\"createManyAndReturn\\", \\"deleteOne\\", \\"updateOne\\", \\"deleteMany\\", \\"updateMany\\", \\"updateManyAndReturn\\", \\"upsertOne\\"
   ];
   for (const resolversEnhanceMapKey of Object.keys(resolversEnhanceMap)) {
     const modelName = resolversEnhanceMapKey as keyof typeof resolversEnhanceMap;
@@ -754,7 +762,8 @@ const outputsInfo = {
   PostCountAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\", \\"_all\\"],
   PostMinAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
   PostMaxAggregate: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
-  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"]
+  CreateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
+  UpdateManyAndReturnPost: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"]
 };
 
 type OutputTypesNames = keyof typeof outputTypes;
@@ -808,7 +817,7 @@ const inputsInfo = {
   DateTimeFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   BoolFilter: [\\"equals\\", \\"not\\"],
   StringNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\"],
-  JsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
+  JsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
   SortOrderInput: [\\"sort\\", \\"nulls\\"],
   PostCountOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\", \\"metadata\\"],
   PostMaxOrderByAggregateInput: [\\"uuid\\", \\"createdAt\\", \\"updatedAt\\", \\"published\\", \\"title\\", \\"content\\"],
@@ -817,7 +826,7 @@ const inputsInfo = {
   DateTimeWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   BoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"mode\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
-  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
+  JsonWithAggregatesFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   StringFieldUpdateOperationsInput: [\\"set\\"],
   DateTimeFieldUpdateOperationsInput: [\\"set\\"],
   BoolFieldUpdateOperationsInput: [\\"set\\"],
@@ -832,7 +841,7 @@ const inputsInfo = {
   NestedBoolWithAggregatesFilter: [\\"equals\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedStringNullableWithAggregatesFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"contains\\", \\"startsWith\\", \\"endsWith\\", \\"not\\", \\"_count\\", \\"_min\\", \\"_max\\"],
   NestedIntNullableFilter: [\\"equals\\", \\"in\\", \\"notIn\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"],
-  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_contains\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"]
+  NestedJsonFilter: [\\"equals\\", \\"path\\", \\"mode\\", \\"string_contains\\", \\"string_starts_with\\", \\"string_ends_with\\", \\"array_starts_with\\", \\"array_ends_with\\", \\"array_contains\\", \\"lt\\", \\"lte\\", \\"gt\\", \\"gte\\", \\"not\\"]
 };
 
 type InputTypesNames = keyof typeof inputTypes;

--- a/tests/regression/__snapshots__/outputs.ts.snap
+++ b/tests/regression/__snapshots__/outputs.ts.snap
@@ -242,6 +242,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManyAndReturnExample } from \\"./UpdateManyAndReturnExample\\";
 "
 `;
 
@@ -487,6 +488,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManyAndReturnExample } from \\"./UpdateManyAndReturnExample\\";
 "
 `;
 
@@ -531,6 +533,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyAndReturnFirstModel } from \\"./UpdateManyAndReturnFirstModel\\";
+export { UpdateManyAndReturnSecondModel } from \\"./UpdateManyAndReturnSecondModel\\";
 export * from \\"./args\\";
 "
 `;
@@ -576,6 +580,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyAndReturnFirstModel } from \\"./UpdateManyAndReturnFirstModel\\";
+export { UpdateManyAndReturnSecondModel } from \\"./UpdateManyAndReturnSecondModel\\";
 export * from \\"./args\\";
 "
 `;
@@ -929,6 +935,7 @@ export { SampleGroupBy } from \\"./SampleGroupBy\\";
 export { SampleMaxAggregate } from \\"./SampleMaxAggregate\\";
 export { SampleMinAggregate } from \\"./SampleMinAggregate\\";
 export { SampleSumAggregate } from \\"./SampleSumAggregate\\";
+export { UpdateManyAndReturnSample } from \\"./UpdateManyAndReturnSample\\";
 "
 `;
 


### PR DESCRIPTION
This PR updates the DMMF generation to support DMMF outputted from Prisma 6.19. It also adds supports for the new clients and aliasing Prisma introduced since ver 5.

I use this project as part of [Hack the North](https://hackthenorth.com/), a student run hackathon, and our backend is coupled extremely tightly to this framework and GQL as a whole. We've been on Prisma 5 for a while and would like to move to Prisma 6, which is why I am sending this patch.

I spent a decent amount of time reading DMMF and this repo to familarize myself with the general structure/logic behind generation, so I could police my coding agent when I was using it.


AI Usage:

This final PR was constructed with the help of agents, with careful and thoughtful human supervision.
My approach was to find the 2 commits where Prisma 5 left off, then find out where 6.19 was. For each of the commits, I asked the agent to collect the changes in the DMMF, and write it to a SQL db with the commit hash. I then had another coding agent go over each of those hashes and scan this repo for areas where it could apply changes. 

I then confirmed the changes myself by hand in the main Prisma repo by looking at the PRs. I looked for tests to add where I felt appropriate, and instructed the agent to add them.

I did not update experiments or examples.